### PR TITLE
Expose Cosmoz.Mixins.translatable() mixin wrapper for behavior

### DIFF
--- a/cosmoz-i18next.js
+++ b/cosmoz-i18next.js
@@ -211,7 +211,7 @@
 	};
 
 	Cosmoz.Mixins = Cosmoz.Mixins || {};
-	Cosmoz.Mixins.translatable = baseClass => class extends Polymer.mixinBehaviors([Cosmoz.TranslatableBehavior], baseClass);
+	Cosmoz.Mixins.translatable = baseClass => Polymer.mixinBehaviors([Cosmoz.TranslatableBehavior], baseClass);
 
 	Polymer({
 		is: 'cosmoz-i18next',

--- a/cosmoz-i18next.js
+++ b/cosmoz-i18next.js
@@ -210,6 +210,9 @@
 		}
 	};
 
+	Cosmoz.Mixins = Cosmoz.Mixins || {};
+	Cosmoz.Mixins.translatable = baseClass => class extends Polymer.mixinBehaviors([Cosmoz.TranslatableBehavior], baseClass);
+
 	Polymer({
 		is: 'cosmoz-i18next',
 		properties: {


### PR DESCRIPTION
Makes it easier to migrate to the mixin during a transition phase
to later drop the behavior once all dependencies are upgraded.

Signed-off-by: Patrik Kullman <patrik.kullman@neovici.se>