### PR TITLE
9 - Update to Polymer 2.x - part 3

### DIFF
--- a/cosmoz-i18next.js
+++ b/cosmoz-i18next.js
@@ -218,8 +218,7 @@
 		static get is() {
 			return 'cosmoz-i18next';
 		}
-		// eslint-disable-next-line max-lines-per-function
-		static get properties() {
+		static get properties() { // eslint-disable-line max-lines-per-function
 			return {
 				domain: {
 					type: String,

--- a/cosmoz-i18next.js
+++ b/cosmoz-i18next.js
@@ -1,3 +1,4 @@
+/*global Polymer */
 (function () {
 	'use strict';
 
@@ -213,47 +214,51 @@
 	Cosmoz.Mixins = Cosmoz.Mixins || {};
 	Cosmoz.Mixins.translatable = baseClass => Polymer.mixinBehaviors([Cosmoz.TranslatableBehavior], baseClass);
 
-	Polymer({
-		is: 'cosmoz-i18next',
-		properties: {
-			domain: {
-				type: String,
-				value: 'messages'
-			},
-			interpolationPrefix: {
-				type: String,
-				value: '__'
-			},
-			interpolationSuffix: {
-				type: String,
-				value: '__'
-			},
-			language: {
-				type: String,
-				value: 'en'
-			},
-			namespace: {
-				type: String,
-				value: 'translation'
-			},
-			translations: {
-				type: Object,
-				observer: '_setTranslations'
-			},
-			keySeparator: {
-				type: String,
-				value: '.'
-			},
-			nsSeparator: {
-				type: String,
-				value: ':'
-			}
-		},
-		_setTranslations() {
-			i18n.removeResourceBundle(this.language, this.namespace);
-			i18n.addResources(this.language, this.namespace, this.translations);
-			translationElements.forEach(element => element.set('t', {}));
-		},
+	class CosmozI18Next extends Polymer.Element {
+		static get is() {
+			return 'cosmoz-i18next';
+		}
+		static get properties() {
+
+			return {
+				domain: {
+					type: String,
+					value: 'messages'
+				},
+				interpolationPrefix: {
+					type: String,
+					value: '__'
+				},
+				interpolationSuffix: {
+					type: String,
+					value: '__'
+				},
+				language: {
+					type: String,
+					value: 'en'
+				},
+				namespace: {
+					type: String,
+					value: 'translation'
+				},
+				translations: {
+					type: Object,
+					observer: function () { // eslint-disable-line object-shorthand
+						i18n.removeResourceBundle(this.language, this.namespace);
+						i18n.addResources(this.language, this.namespace, this.translations);
+						translationElements.forEach(element => element.set('t', {}));
+					}
+				},
+				keySeparator: {
+					type: String,
+					value: '.'
+				},
+				nsSeparator: {
+					type: String,
+					value: ':'
+				}
+			};
+		}
 		ready() {
 			i18n.init({
 				interpolationPrefix: this.interpolationPrefix,
@@ -264,5 +269,6 @@
 				resStore: {}
 			});
 		}
-	});
+	}
+	customElements.define(CosmozI18Next.is, CosmozI18Next);
 }());

--- a/cosmoz-i18next.js
+++ b/cosmoz-i18next.js
@@ -218,8 +218,8 @@
 		static get is() {
 			return 'cosmoz-i18next';
 		}
+		// eslint-disable-next-line max-lines-per-function
 		static get properties() {
-
 			return {
 				domain: {
 					type: String,

--- a/cosmoz-t.html
+++ b/cosmoz-t.html
@@ -21,6 +21,9 @@
 				// FIXME: remove this when TranslatableBehavior is a 2.x mixin
 				return Cosmoz.TranslatableBehavior._.apply(this, arguments);
 			}
+			t() {
+				return Cosmoz.TranslatableBehavior.t.apply(this, arguments);
+			}
 		}
 		customElements.define(CosmozT.is, CosmozT);
 	</script>

--- a/cosmoz-t.html
+++ b/cosmoz-t.html
@@ -6,9 +6,7 @@
 	<script>
 		/*global Polymer*/
 		window.Cosmoz = window.Cosmoz || {};
-		class CosmozT extends Polymer.mixinBehaviors([
-			Cosmoz.TranslatableBehavior
-		], Polymer.Element) {
+		class CosmozT extends Cosmoz.Mixins.translatable(Polymer.Element) {
 			static get is() {
 				return 'cosmoz-t';
 			}

--- a/cosmoz-t.html
+++ b/cosmoz-t.html
@@ -17,6 +17,10 @@
 					}
 				};
 			}
+			_() {
+				// FIXME: remove this when TranslatableBehavior is a 2.x mixin
+				return Cosmoz.TranslatableBehavior._.apply(this, arguments);
+			}
 		}
 		customElements.define(CosmozT.is, CosmozT);
 	</script>

--- a/cosmoz-t.html
+++ b/cosmoz-t.html
@@ -1,20 +1,25 @@
+
 <link rel="import" href="cosmoz-i18next.html"/>
 
 <dom-module id="cosmoz-t">
 	<template>[[ _(input, t) ]]</template>
 	<script>
-		(function () {
-			Polymer({
-				is: 'cosmoz-t',
-				properties: {
+		/*global Polymer*/
+		window.Cosmoz = window.Cosmoz || {};
+		class CosmozT extends Polymer.mixinBehaviors([
+			Cosmoz.TranslatableBehavior
+		], Polymer.Element) {
+			static get is() {
+				return 'cosmoz-t';
+			}
+			static get properties() {
+				return {
 					input: {
 						type: String
 					}
-				},
-				behaviors: [
-					Cosmoz.TranslatableBehavior
-				]
-			});
-		}());
+				};
+			}
+		}
+		customElements.define(CosmozT.is, CosmozT);
 	</script>
 </dom-module>

--- a/cosmoz-t.html
+++ b/cosmoz-t.html
@@ -14,15 +14,15 @@
 				return {
 					input: {
 						type: String
+					},
+					t: {
+						type: Object
 					}
 				};
 			}
 			_() {
 				// FIXME: remove this when TranslatableBehavior is a 2.x mixin
 				return Cosmoz.TranslatableBehavior._.apply(this, arguments);
-			}
-			t() {
-				return Cosmoz.TranslatableBehavior.t.apply(this, arguments);
 			}
 		}
 		customElements.define(CosmozT.is, CosmozT);

--- a/demo/index.html
+++ b/demo/index.html
@@ -132,9 +132,7 @@
 			/*global Polymer*/
 			window.Cosmoz  = window.Cosmoz || {};
 
-			class XTranslatable extends Polymer.mixinBehaviors([
-				Cosmoz.TranslatableBehavior
-			], Polymer.Element) {
+			class XTranslatable extends Cosmoz.Mixins.translatable(Polymer.Element) {
 				static get is() {
 					return 'x-translatable';
 				}

--- a/demo/index.html
+++ b/demo/index.html
@@ -129,24 +129,29 @@
 		</template>
 
 		<script type="text/javascript">
-			Polymer({
-				behaviors: [
-					Cosmoz.TranslatableBehavior,
-				],
+			/*global Polymer*/
+			window.Cosmoz  = window.Cosmoz || {};
 
-				is: 'x-translatable',
-
-				properties: {
-					nullContext: {
-						type: String,
-						value: null
-					},
-					undefinedContext: {
-						type: String,
-						value: undefined
-					}
+			class XTranslatable extends Polymer.mixinBehaviors([
+				Cosmoz.TranslatableBehavior
+			], Polymer.Element) {
+				static get is() {
+					return 'x-translatable';
 				}
-			});
+				static get properties() {
+					return {
+						nullContext: {
+							type: String,
+							value: null
+						},
+						undefinedContext: {
+							type: String,
+							value: undefined
+						}
+					};
+				}
+			}
+			customElements.define(XTranslatable.is, XTranslatable);
 		</script>
 	</dom-module>
 	<script type="text/javascript">


### PR DESCRIPTION
Update to Polymer 2.x - part 3.

Need some help on this one. The demo warns that `getTranslations` is not declared, but the demo works and the function runs. The behavior should probably be class-based but it is mentioned in a lot of places in frontend.

Thanks to @megheaiulian for solving problems related to `_` and `t`.

Issue is #9.