### PR TITLE
Components, Test, detaching behavior from mixin

### DIFF
--- a/cosmoz-i18next.js
+++ b/cosmoz-i18next.js
@@ -7,6 +7,7 @@
 	const translationElements = [];
 	/**
 	 * Translation behavior using the I18next internationalization framework.
+	 * TODO: Remove behavior when all dependants use the mixin instead.
 	 *
 	 * @polymerBehavior */
 	Cosmoz.TranslatableBehavior = {
@@ -211,8 +212,218 @@
 		}
 	};
 
+	/**
+	* @namespace Cosmoz.Mixins
+	*/
 	Cosmoz.Mixins = Cosmoz.Mixins || {};
-	Cosmoz.Mixins.translatable = baseClass => Polymer.mixinBehaviors([Cosmoz.TranslatableBehavior], baseClass);
+
+	/**
+	* @memberof Cosmoz.Mixins
+	*/
+
+	Cosmoz.Mixins.translatable = baseClass => class extends baseClass {
+		static get properties() {
+			return {
+				t: {
+					type: Object,
+					value() {
+						return {};
+					}
+				}
+			};
+		}
+
+		_argumentsToObject(args, skipnum) {
+			const argsArray = Array.prototype.slice.call(args, skipnum);
+			return this._arrayToObject(argsArray);
+		}
+
+		_arrayToObject(array) {
+			const ctx = this,
+				object = {};
+
+			array.forEach((item, index) => {
+				if (object.count === undefined && typeof item === 'number') {
+					object.count = item;
+				}
+				// Don't send the 't' kicker to i18n for arguments
+				if (item !== ctx.t) {
+					object[index] = item;
+				}
+			});
+			return object;
+		}
+
+		_ensureInitialized() {
+			if (!i18n.isInitialized()) {
+				// default i18n init, to ensure translate function will return something
+				// even when there is no <i18next> element in the page.
+				i18n.init({lng: 'en', resStore: { en: {}}, fallbackLng: false});
+			}
+		}
+		/**
+		 * Convenience method for gettext. Translates a text.
+		 *
+		 * @param {string} key Translation key.
+		 * @returns {string} Translated text.
+		 */
+		_(key) {
+			return this.gettextgeneric(key, arguments);
+		}
+
+		connectedCallback() {
+			super.connectedCallback();
+			translationElements.push(this);
+		}
+
+		disconnectedCallback() {
+			super.disconnectedCallback();
+			const i = translationElements.indexOf(this);
+			if (i >= 0) {
+				translationElements.splice(i, 1);
+			}
+		}
+		/**
+		 * Translates a text.
+		 *
+		 * Example of basic translation:
+		 * `_(string, t)`
+		 *   <div>{{ _(‘My translation’, t) }}</div>
+		 *
+		 * Example of basic translation with interpolation:
+		 * `_(string, [args], t)`
+		 *   <div>{{ _(‘Hello {0}’, user.name, t) }}</div>
+		 *
+		 * @param {string} key Text to translate.
+		 * @param {object} t Behavior t object.
+		 * @return {string} Translated text.
+		 */
+		gettext(key) {
+			return this.gettextgeneric(key, arguments);
+		}
+		/**
+		 * Generic handler for text translation
+		 *
+		 * @param {string} key Text to translate.
+		 * @param {array} callerArgs Arguments from the calling function.
+		 * @return {string} Translated text.
+		 */
+		gettextgeneric(key, callerArgs) {
+			this._ensureInitialized();
+			const args = this._argumentsToObject(callerArgs, 1);
+			// Don't make i18next fetch more translations
+			delete args.count;
+			return i18n.t(key, args);
+		}
+
+		/**
+		 * Plural version of gettext. Translates a text to the current locale
+		 * using the first numeric argument after the two first arguments to
+		 * determine if output should be singular or plural.
+		 *
+		 * Example of translation in singular or plural:
+		 * `ngettext(singular, plural, count, t)`
+		 * <div>{{ ngettext(‘My translation’,
+		 *   ‘My translations’, count, t) }}</div>
+		 *
+		 * Example of translation in singular or plural with interpolation:
+		 * `ngettext(singular, plural, [count and other args], t)`
+		 * <div>{{ ngettext(‘My translation for “{1}”’,
+		 *   ‘My {0} translations for “{1}”’, count, ‘hello’, t) }}</div>
+		 *
+		 * @param {string} singular Singular text variant.
+		 * @param {string} plural Plural text variant.
+		 * @return {string} Translated text.
+		 */
+		ngettext(singular, plural) {
+			this._ensureInitialized();
+
+			const
+				args = this._argumentsToObject(arguments, 2),
+				n = args.count;
+			let key;
+
+			delete args.count;
+
+			if (i18n.pluralExtensions.needsPlural(i18n.lng(), n)) {
+				args.defaultValue = plural;
+				key = i18n.options.ns.defaultNs + i18n.options.nsseparator + singular + i18n.options.pluralSuffix;
+			} else {
+				key = singular;
+				args.defaultValue = singular;
+			}
+			return i18n.t(key, args);
+		}
+
+		/**
+		 * Translates a text using a specific context.
+		 *
+		 * Example of translation with context:
+		 * `pgettext(context, ‘text’, t)`
+		 *   <div>{{ pgettext(‘Cancel Invoice’, ‘Cancel’, t) }}</div>
+		 *
+		 * Example of translation including context with interpolation:
+		 * `pgettext(context, ‘text’, [args], t)`
+		 * <div>{{ pgettext(‘Cancel Invoice’, ‘Cancel {0}’,
+		 *   document.type, t) }}</div>
+		 *
+		 * @param {string} context Context text.
+		 * @param {string} key Text to translate.
+		 * @return {string} Translated text.
+		 */
+		pgettext(context, key) {
+			this._ensureInitialized();
+
+			const args = this._argumentsToObject(arguments, 2);
+			args.context = context;
+			// Don't make i18next fetch more translations
+			delete args.count;
+			return i18n.t(key, args);
+		}
+
+		/**
+		 * Translates a text in singular or plural with a specific context.
+		 *
+		 * Example of translation in singular or plural with context:
+		 * `npgettext(context, singular, plural, count, t)`
+		 * <div>{{ npgettext('Cancel invoice', ‘My cancellation’,
+		 *   ‘My {0} cancellations’, count, t) }}</div>
+		 *
+		 * Example of translation in singular or plural with context and
+		 * interpolation:
+		 * `npgettext(context, singular, plural, count, t)`
+		 * <div>{{ npgettext('Cancel invoice', ‘My {1} cancellation’,
+		 *   ‘My {0} {1} cancellations’, count, document.type, t) }}</div>
+		 *
+		 * @param {string} context Context text.
+		 * @param {string} singular Singular text variant.
+		 * @param {string} plural Plural text variant.
+		 * @return {string} Translated text.
+		 */
+		npgettext(context, singular, plural) {
+			this._ensureInitialized();
+
+			const
+				args = this._argumentsToObject(arguments, 3),
+				n = args.count,
+				contextKeyPart = context
+					? '_' + context
+					: '';
+			let key = singular;
+
+			delete args.count;
+
+			if (i18n.pluralExtensions.needsPlural(i18n.lng(), n)) {
+				args.defaultValue = plural;
+				key = i18n.options.ns.defaultNs + i18n.options.nsseparator + singular + contextKeyPart + i18n.options.pluralSuffix;
+			} else {
+				key = singular;
+				args.context = context;
+			}
+
+			return i18n.t(key, args);
+		}
+	};
 
 	class CosmozI18Next extends Polymer.Element {
 		static get is() {

--- a/cosmoz-t.html
+++ b/cosmoz-t.html
@@ -20,10 +20,6 @@
 					}
 				};
 			}
-			_() {
-				// FIXME: remove this when TranslatableBehavior is a 2.x mixin
-				return Cosmoz.TranslatableBehavior._.apply(this, arguments);
-			}
 		}
 		customElements.define(CosmozT.is, CosmozT);
 	</script>

--- a/test/basic.html
+++ b/test/basic.html
@@ -28,21 +28,15 @@
 		</test-fixture>
 
 		<script>
+			suite('basic', () => {
+				let element;
 
-			suite('basic', function () {
-				var element;
-
-				setup(function (done){
+				setup(done => {
 					element = fixture('basic');
 					done();
 				});
 
-				test('instantiates a cosmoz-i18next element', function (done){
-					assert.equal(element.is, 'cosmoz-i18next');
-					done();
-				});
-
-				test('sets defaults', function (done){
+				test('sets defaults', done => {
 					assert.equal(element.domain, 'messages');
 					assert.equal(element.interpolationPrefix, '__');
 					assert.equal(element.interpolationSuffix, '__');
@@ -56,22 +50,17 @@
 
 			});
 
-			suite('basic-t', function () {
-				var element;
+			suite('basic-t', () => {
+				let element;
 
-				setup(function (done){
+				setup(done =>{
 					element = fixture('basic-t');
 					done();
 				});
 
-				test('instantiates a cosmoz-t element', function (done){
-					assert.equal(element.is, 'cosmoz-t');
-					done();
-				});
-
-				test('translates key', function (done){
+				test('translates key', done => {
 					assert.isFunction(element._);
-					flush(function (){
+					flush(() => {
 						assert.isTrue(i18n.isInitialized());
 						assert.equal(element._('Hello __0__', 'John Doe'), 'Hello John Doe');
 						done();


### PR DESCRIPTION
Components, Test, detaching behavior from mixin.

This detaches the connection between the behavior and the mixin, so the dependents can start to use the mixin instead and drop all workarounds that use the behavior.

The reason for this is because there are some dependents that relies on that the mixin in fact is a behavior and this hinders the goal to completely replace the behavior with a pure mixin.

Here is an example, simply removing the `_()` function does not work, because `yarn lint` / Travis-CI then won't be able to find the function if the mixin is a covered behavior:
```
class OmnitableColumnListData extends Cosmoz.Mixins.translatable(
  Polymer.mixinBehaviors([Cosmoz.TemplateHelperBehavior], Polymer.Element)
) {
...
  _() {
    // FIXME: remove this when TranslatableBehavior is a 2.x mixin
    return Cosmoz.TranslatableBehavior._.apply(this, arguments);
  }
...
}
```

Testing, run `yarn install; yarn start`, then add `demo/` to the address. Or better, in `cosmoz-omnitable/bower_components` replace `cosmoz-i18next` with a `cosmoz-i18next` using this pull request and remove the `_()` function in `cosmoz-omnitable-column-list-data.html` and run `yarn lint`, it should not complain.

Issue is https://github.com/Neovici/cosmoz-frontend/issues/815.