### PR TITLE
Components, Test, converting to class-style

### DIFF
--- a/analysis.json
+++ b/analysis.json
@@ -1,5 +1,23 @@
 {
   "schema_version": "1.0.0",
+  "namespaces": [
+    {
+      "name": "Cosmoz.Mixins",
+      "description": "",
+      "summary": "",
+      "sourceRange": {
+        "file": "cosmoz-i18next.js",
+        "start": {
+          "line": 11,
+          "column": 1
+        },
+        "end": {
+          "line": 11,
+          "column": 37
+        }
+      }
+    }
+  ],
   "elements": [
     {
       "description": "`<cosmoz-i18next>` is a translation component based on i18next\n\n### Usage\n\nUse the component as a singleton to interface the i18next library.\n\n    <cosmoz-i18next translations=\"{{ translations }}\"></cosmoz-i18next>",
@@ -7,184 +25,1023 @@
       "path": "cosmoz-i18next.js",
       "properties": [
         {
-          "name": "domain",
+          "name": "__dataClientsReady",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1098,
+              "column": 8
+            },
+            "end": {
+              "line": 1098,
+              "column": 32
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataPendingClients",
+          "type": "Array",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1100,
+              "column": 8
+            },
+            "end": {
+              "line": 1100,
+              "column": 34
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataToNotify",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1102,
+              "column": 8
+            },
+            "end": {
+              "line": 1102,
+              "column": 28
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataLinkedPaths",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1104,
+              "column": 8
+            },
+            "end": {
+              "line": 1104,
+              "column": 31
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataHasPaths",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1106,
+              "column": 8
+            },
+            "end": {
+              "line": 1106,
+              "column": 28
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataCompoundStorage",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1108,
+              "column": 8
+            },
+            "end": {
+              "line": 1108,
+              "column": 35
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataHost",
+          "type": "Polymer_PropertyEffects",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1110,
+              "column": 8
+            },
+            "end": {
+              "line": 1110,
+              "column": 24
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataTemp",
+          "type": "!Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1112,
+              "column": 8
+            },
+            "end": {
+              "line": 1112,
+              "column": 24
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataClientsInitialized",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1114,
+              "column": 8
+            },
+            "end": {
+              "line": 1114,
+              "column": 38
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__data",
+          "type": "!Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1116,
+              "column": 8
+            },
+            "end": {
+              "line": 1116,
+              "column": 20
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataPending",
+          "type": "!Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1118,
+              "column": 8
+            },
+            "end": {
+              "line": 1118,
+              "column": 27
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataOld",
+          "type": "!Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1120,
+              "column": 8
+            },
+            "end": {
+              "line": 1120,
+              "column": 23
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__computeEffects",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1122,
+              "column": 8
+            },
+            "end": {
+              "line": 1122,
+              "column": 30
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__reflectEffects",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1124,
+              "column": 8
+            },
+            "end": {
+              "line": 1124,
+              "column": 30
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__notifyEffects",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1126,
+              "column": 8
+            },
+            "end": {
+              "line": 1126,
+              "column": 29
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__propagateEffects",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1128,
+              "column": 8
+            },
+            "end": {
+              "line": 1128,
+              "column": 32
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__observeEffects",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1130,
+              "column": 8
+            },
+            "end": {
+              "line": 1130,
+              "column": 30
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__readOnly",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1132,
+              "column": 8
+            },
+            "end": {
+              "line": 1132,
+              "column": 24
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__templateInfo",
+          "type": "!TemplateInfo",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1134,
+              "column": 8
+            },
+            "end": {
+              "line": 1134,
+              "column": 28
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "PROPERTY_EFFECT_TYPES",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1137,
+              "column": 6
+            },
+            "end": {
+              "line": 1139,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_template",
+          "type": "HTMLTemplateElement",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 486,
+              "column": 8
+            },
+            "end": {
+              "line": 486,
+              "column": 23
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_importPath",
+          "type": "string",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 488,
+              "column": 8
+            },
+            "end": {
+              "line": 488,
+              "column": 25
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "rootPath",
           "type": "string",
           "description": "",
           "privacy": "public",
           "sourceRange": {
+            "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 204,
-              "column": 3
+              "line": 490,
+              "column": 8
             },
             "end": {
-              "line": 207,
-              "column": 4
+              "line": 490,
+              "column": 22
             }
           },
           "metadata": {
-            "polymer": {}
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "importPath",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 492,
+              "column": 8
+            },
+            "end": {
+              "line": 492,
+              "column": 24
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "root",
+          "type": "(StampedTemplate | HTMLElement | ShadowRoot)",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 494,
+              "column": 8
+            },
+            "end": {
+              "line": 494,
+              "column": 18
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "$",
+          "type": "!Object.<string, !Element>",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 496,
+              "column": 8
+            },
+            "end": {
+              "line": 496,
+              "column": 15
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "domain",
+          "type": "string | null | undefined",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 248,
+              "column": 4
+            },
+            "end": {
+              "line": 251,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "String"
+            }
           },
           "defaultValue": "\"messages\""
         },
         {
           "name": "interpolationPrefix",
-          "type": "string",
+          "type": "string | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 208,
-              "column": 3
+              "line": 252,
+              "column": 4
             },
             "end": {
-              "line": 211,
-              "column": 4
+              "line": 255,
+              "column": 5
             }
           },
           "metadata": {
-            "polymer": {}
+            "polymer": {
+              "attributeType": "String"
+            }
           },
           "defaultValue": "\"__\""
         },
         {
           "name": "interpolationSuffix",
-          "type": "string",
+          "type": "string | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 212,
-              "column": 3
+              "line": 256,
+              "column": 4
             },
             "end": {
-              "line": 215,
-              "column": 4
+              "line": 259,
+              "column": 5
             }
           },
           "metadata": {
-            "polymer": {}
+            "polymer": {
+              "attributeType": "String"
+            }
           },
           "defaultValue": "\"__\""
         },
         {
           "name": "language",
-          "type": "string",
+          "type": "string | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 216,
-              "column": 3
+              "line": 260,
+              "column": 4
             },
             "end": {
-              "line": 219,
-              "column": 4
+              "line": 263,
+              "column": 5
             }
           },
           "metadata": {
-            "polymer": {}
+            "polymer": {
+              "attributeType": "String"
+            }
           },
           "defaultValue": "\"en\""
         },
         {
           "name": "namespace",
-          "type": "string",
+          "type": "string | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 220,
-              "column": 3
+              "line": 264,
+              "column": 4
             },
             "end": {
-              "line": 223,
-              "column": 4
+              "line": 267,
+              "column": 5
             }
           },
           "metadata": {
-            "polymer": {}
+            "polymer": {
+              "attributeType": "String"
+            }
           },
           "defaultValue": "\"translation\""
         },
         {
           "name": "translations",
-          "type": "Object",
+          "type": "Object | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 224,
-              "column": 3
+              "line": 268,
+              "column": 4
             },
             "end": {
-              "line": 227,
-              "column": 4
+              "line": 275,
+              "column": 5
             }
           },
           "metadata": {
             "polymer": {
-              "observer": "\"_setTranslations\""
+              "observer": "UNKNOWN",
+              "attributeType": "Object"
             }
           }
         },
         {
           "name": "keySeparator",
-          "type": "string",
+          "type": "string | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 228,
-              "column": 3
+              "line": 276,
+              "column": 4
             },
             "end": {
-              "line": 231,
-              "column": 4
+              "line": 279,
+              "column": 5
             }
           },
           "metadata": {
-            "polymer": {}
+            "polymer": {
+              "attributeType": "String"
+            }
           },
           "defaultValue": "\".\""
         },
         {
           "name": "nsSeparator",
-          "type": "string",
+          "type": "string | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 232,
-              "column": 3
+              "line": 280,
+              "column": 4
             },
             "end": {
-              "line": 235,
-              "column": 4
+              "line": 283,
+              "column": 5
             }
           },
           "metadata": {
-            "polymer": {}
+            "polymer": {
+              "attributeType": "String"
+            }
           },
           "defaultValue": "\":\""
         }
       ],
       "methods": [
         {
-          "name": "_setTranslations",
-          "description": "",
+          "name": "_stampTemplate",
+          "description": "Stamps the provided template and performs instance-time setup for\nPolymer template features, including data bindings, declarative event\nlisteners, and the `this.$` map of `id`'s to nodes.  A document fragment\nis returned containing the stamped DOM, ready for insertion into the\nDOM.\n\nThis method may be called more than once; however note that due to\n`shadycss` polyfill limitations, only styles from templates prepared\nusing `ShadyCSS.prepareTemplate` will be correctly polyfilled (scoped\nto the shadow root and support CSS custom properties), and note that\n`ShadyCSS.prepareTemplate` may only be called once per element. As such,\nany styles required by in runtime-stamped templates must be included\nin the main element template.",
           "privacy": "protected",
           "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 237,
-              "column": 2
+              "line": 2424,
+              "column": 6
             },
             "end": {
-              "line": 243,
-              "column": 3
+              "line": 2449,
+              "column": 7
             }
           },
           "metadata": {},
-          "params": []
+          "params": [
+            {
+              "name": "template",
+              "type": "!HTMLTemplateElement",
+              "description": "Template to stamp"
+            }
+          ],
+          "return": {
+            "type": "!StampedTemplate",
+            "desc": "Cloned template content"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_addMethodEventListenerToNode",
+          "description": "Adds an event listener by method name for the event provided.\n\nThis method generates a handler function that looks up the method\nname at handling time.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 460,
+              "column": 6
+            },
+            "end": {
+              "line": 465,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "!Node",
+              "description": "Node to add listener on"
+            },
+            {
+              "name": "eventName",
+              "type": "string",
+              "description": "Name of event"
+            },
+            {
+              "name": "methodName",
+              "type": "string",
+              "description": "Name of method"
+            },
+            {
+              "name": "context",
+              "type": "*=",
+              "description": "Context the method will be called on (defaults\n  to `node`)"
+            }
+          ],
+          "return": {
+            "type": "Function",
+            "desc": "Generated handler function"
+          },
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "_addEventListenerToNode",
+          "description": "Override point for adding custom or simulated event handling.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 475,
+              "column": 6
+            },
+            "end": {
+              "line": 477,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "!Node",
+              "description": "Node to add event listener to"
+            },
+            {
+              "name": "eventName",
+              "type": "string",
+              "description": "Name of event"
+            },
+            {
+              "name": "handler",
+              "type": "function (!Event): void",
+              "description": "Listener function to add"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "_removeEventListenerFromNode",
+          "description": "Override point for adding custom or simulated event handling.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 487,
+              "column": 6
+            },
+            "end": {
+              "line": 489,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "!Node",
+              "description": "Node to remove event listener from"
+            },
+            {
+              "name": "eventName",
+              "type": "string",
+              "description": "Name of event"
+            },
+            {
+              "name": "handler",
+              "type": "function (!Event): void",
+              "description": "Listener function to remove"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "_createPropertyAccessor",
+          "description": "Creates a setter/getter pair for the named property with its own\nlocal storage.  The getter returns the value in the local storage,\nand the setter calls `_setProperty`, which updates the local storage\nfor the property and enqueues a `_propertiesChanged` callback.\n\nThis method may be called on a prototype or an instance.  Calling\nthis method may overwrite a property value that already exists on\nthe prototype/instance by creating the accessor.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 106,
+              "column": 8
+            },
+            "end": {
+              "line": 115,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of the property"
+            },
+            {
+              "name": "readOnly",
+              "type": "boolean=",
+              "description": "When true, no setter is created; the\n  protected `_setProperty` function must be used to set the property"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_addPropertyToAttributeMap",
+          "description": "Adds the given `property` to a map matching attribute names\nto property names, using `attributeNameForProperty`. This map is\nused when deserializing attribute values to properties.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 124,
+              "column": 8
+            },
+            "end": {
+              "line": 132,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of the property"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_definePropertyAccessor",
+          "description": "Defines a property accessor for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 140,
+              "column": 9
+            },
+            "end": {
+              "line": 153,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of the property"
+            },
+            {
+              "name": "readOnly",
+              "type": "boolean=",
+              "description": "When true, no setter is created"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
         },
         {
           "name": "ready",
@@ -192,19 +1049,2929 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 244,
+              "line": 286,
               "column": 2
             },
             "end": {
-              "line": 253,
+              "line": 295,
               "column": 3
             }
           },
           "metadata": {},
-          "params": []
+          "params": [],
+          "return": {
+            "type": "void"
+          }
+        },
+        {
+          "name": "_initializeProperties",
+          "description": "Overrides the default `Polymer.PropertyAccessors` to ensure class\nmetaprogramming related to property accessors and effects has\ncompleted (calls `finalize`).\n\nIt also initializes any property defaults provided via `value` in\n`properties` metadata.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 511,
+              "column": 6
+            },
+            "end": {
+              "line": 543,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_initializeInstanceProperties",
+          "description": "Called at ready time with bag of instance properties that overwrote\naccessors when the element upgraded.\n\nThe default implementation sets these properties back into the\nsetter at ready time.  This method is provided as an override\npoint for customizing or providing more efficient initialization.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 222,
+              "column": 8
+            },
+            "end": {
+              "line": 224,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "Bag of property values that were overwritten\n  when creating property accessors."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_setProperty",
+          "description": "Updates the local storage for a property (via `_setPendingProperty`)\nand enqueues a `_proeprtiesChanged` callback.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 235,
+              "column": 8
+            },
+            "end": {
+              "line": 239,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of the property"
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "Value to set"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_getProperty",
+          "description": "Returns the value for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 247,
+              "column": 8
+            },
+            "end": {
+              "line": 249,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of property"
+            }
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Value for the given property"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_setPendingProperty",
+          "description": "Updates the local storage for a property, records the previous value,\nand adds it to the set of \"pending changes\" that will be passed to the\n`_propertiesChanged` callback.  This method does not enqueue the\n`_propertiesChanged` callback.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 264,
+              "column": 8
+            },
+            "end": {
+              "line": 280,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of the property"
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "Value to set"
+            },
+            {
+              "name": "ext",
+              "type": "boolean=",
+              "description": "Not used here; affordance for closure"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "Returns true if the property changed"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_invalidateProperties",
+          "description": "Marks the properties as invalid, and enqueues an async\n`_propertiesChanged` callback.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 290,
+              "column": 8
+            },
+            "end": {
+              "line": 300,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_enableProperties",
+          "description": "Call to enable property accessor processing. Before this method is\ncalled accessor values will be set but side effects are\nqueued. When called, any pending side effects occur immediately.\nFor elements, generally `connectedCallback` is a normal spot to do so.\nIt is safe to call this method multiple times as it only turns on\nproperty accessors once.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 313,
+              "column": 8
+            },
+            "end": {
+              "line": 322,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_flushProperties",
+          "description": "Calls the `_propertiesChanged` callback with the current set of\npending changes (and old values recorded when pending changes were\nset), and resets the pending set of changes. Generally, this method\nshould not be called in user code.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 333,
+              "column": 8
+            },
+            "end": {
+              "line": 342,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_shouldPropertiesChange",
+          "description": "Called in `_flushProperties` to determine if `_propertiesChanged`\nshould be called. The default implementation returns true if\nproperties are pending. Override to customize when\n`_propertiesChanged` is called.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 356,
+              "column": 8
+            },
+            "end": {
+              "line": 358,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "currentProps",
+              "type": "!Object",
+              "description": "Bag of all current accessor values"
+            },
+            {
+              "name": "changedProps",
+              "type": "!Object",
+              "description": "Bag of properties changed since the last\n  call to `_propertiesChanged`"
+            },
+            {
+              "name": "oldProps",
+              "type": "!Object",
+              "description": "Bag of previous values for each property\n  in `changedProps`"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "true if changedProps is truthy"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_propertiesChanged",
+          "description": "Callback called when any properties with accessors created via\n`_createPropertyAccessor` have been set.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 372,
+              "column": 8
+            },
+            "end": {
+              "line": 373,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "currentProps",
+              "type": "!Object",
+              "description": "Bag of all current accessor values"
+            },
+            {
+              "name": "changedProps",
+              "type": "!Object",
+              "description": "Bag of properties changed since the last\n  call to `_propertiesChanged`"
+            },
+            {
+              "name": "oldProps",
+              "type": "!Object",
+              "description": "Bag of previous values for each property\n  in `changedProps`"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_shouldPropertyChange",
+          "description": "Method called to determine whether a property value should be\nconsidered as a change and cause the `_propertiesChanged` callback\nto be enqueued.\n\nThe default implementation returns `true` if a strict equality\ncheck fails. The method always returns false for `NaN`.\n\nOverride this method to e.g. provide stricter checking for\nObjects/Arrays when using immutable patterns.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 393,
+              "column": 8
+            },
+            "end": {
+              "line": 400,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "New property value"
+            },
+            {
+              "name": "old",
+              "type": "*",
+              "description": "Previous property value"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "Whether the property should be considered a change\n  and enqueue a `_proeprtiesChanged` callback"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "attributeChangedCallback",
+          "description": "Implements native Custom Elements `attributeChangedCallback` to\nset an attribute value to a property via `_attributeToProperty`.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 413,
+              "column": 8
+            },
+            "end": {
+              "line": 420,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "name",
+              "type": "string",
+              "description": "Name of attribute that changed"
+            },
+            {
+              "name": "old",
+              "type": "?string",
+              "description": "Old attribute value"
+            },
+            {
+              "name": "value",
+              "type": "?string",
+              "description": "New attribute value"
+            },
+            {
+              "name": "namespace",
+              "type": "?string",
+              "description": "Attribute namespace."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_attributeToProperty",
+          "description": "Deserializes an attribute to its associated property.\n\nThis method calls the `_deserializeValue` method to convert the string to\na typed value.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 434,
+              "column": 8
+            },
+            "end": {
+              "line": 441,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "attribute",
+              "type": "string",
+              "description": "Name of attribute to deserialize."
+            },
+            {
+              "name": "value",
+              "type": "?string",
+              "description": "of the attribute."
+            },
+            {
+              "name": "type",
+              "type": "*=",
+              "description": "type to deserialize to, defaults to the value\nreturned from `typeForProperty`"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_propertyToAttribute",
+          "description": "Serializes a property to its associated attribute.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 453,
+              "column": 8
+            },
+            "end": {
+              "line": 459,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name to reflect."
+            },
+            {
+              "name": "attribute",
+              "type": "string=",
+              "description": "Attribute name to reflect to."
+            },
+            {
+              "name": "value",
+              "type": "*=",
+              "description": "Property value to refect."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_valueToNodeAttribute",
+          "description": "Sets a typed value to an HTML attribute on a node.\n\nThis method calls the `_serializeValue` method to convert the typed\nvalue to a string.  If the `_serializeValue` method returns `undefined`,\nthe attribute will be removed (this is the default for boolean\ntype `false`).",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 474,
+              "column": 8
+            },
+            "end": {
+              "line": 481,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Element",
+              "description": "Element to set attribute to."
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "Value to serialize."
+            },
+            {
+              "name": "attribute",
+              "type": "string",
+              "description": "Attribute name to serialize to."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_serializeValue",
+          "description": "Converts a typed JavaScript value to a string.\n\nThis method is called when setting JS property values to\nHTML attributes.  Users may override this method to provide\nserialization for custom types.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 494,
+              "column": 8
+            },
+            "end": {
+              "line": 501,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value",
+              "type": "*",
+              "description": "Property value to serialize."
+            }
+          ],
+          "return": {
+            "type": "(string | undefined)",
+            "desc": "String serialized from the provided\nproperty  value."
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_deserializeValue",
+          "description": "Converts a string to a typed JavaScript value.\n\nThis method is called when reading HTML attribute values to\nJS properties.  Users may override this method to provide\ndeserialization for custom `type`s. Types for `Boolean`, `String`,\nand `Number` convert attributes to the expected types.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 515,
+              "column": 8
+            },
+            "end": {
+              "line": 524,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value",
+              "type": "?string",
+              "description": "Value to deserialize."
+            },
+            {
+              "name": "type",
+              "type": "*=",
+              "description": "Type to deserialize the string to."
+            }
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Typed value deserialized from the provided string."
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_initializeProtoProperties",
+          "description": "Overrides `Polymer.PropertyAccessors` implementation to provide a\nmore efficient implementation of initializing properties from\nthe prototype on the instance.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1168,
+              "column": 6
+            },
+            "end": {
+              "line": 1172,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "Properties to initialize on the prototype"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_ensureAttribute",
+          "description": "Ensures the element has the given attribute. If it does not,\nassigns the given value to the attribute.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 193,
+              "column": 6
+            },
+            "end": {
+              "line": 198,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "attribute",
+              "type": "string",
+              "description": "Name of attribute to ensure is set."
+            },
+            {
+              "name": "value",
+              "type": "string",
+              "description": "of the attribute."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_hasAccessor",
+          "description": "Returns true if this library created an accessor for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 300,
+              "column": 6
+            },
+            "end": {
+              "line": 302,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if an accessor was created"
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_isPropertyPending",
+          "description": "Returns true if the specified property has a pending change.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 311,
+              "column": 6
+            },
+            "end": {
+              "line": 313,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "prop",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if property has a pending change"
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_addPropertyEffect",
+          "description": "Equivalent to static `addPropertyEffect` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1206,
+              "column": 6
+            },
+            "end": {
+              "line": 1214,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property that should trigger the effect"
+            },
+            {
+              "name": "type",
+              "type": "string",
+              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+            },
+            {
+              "name": "effect",
+              "type": "Object=",
+              "description": "Effect metadata object"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_removePropertyEffect",
+          "description": "Removes the given property effect.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1224,
+              "column": 6
+            },
+            "end": {
+              "line": 1230,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property the effect was associated with"
+            },
+            {
+              "name": "type",
+              "type": "string",
+              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+            },
+            {
+              "name": "effect",
+              "type": "Object=",
+              "description": "Effect metadata object to remove"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_hasPropertyEffect",
+          "description": "Returns whether the current prototype/instance has a property effect\nof a certain type.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1241,
+              "column": 6
+            },
+            "end": {
+              "line": 1244,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            },
+            {
+              "name": "type",
+              "type": "string=",
+              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if the prototype/instance has an effect of this type"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_hasReadOnlyEffect",
+          "description": "Returns whether the current prototype/instance has a \"read only\"\naccessor for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1254,
+              "column": 6
+            },
+            "end": {
+              "line": 1256,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if the prototype/instance has an effect of this type"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_hasNotifyEffect",
+          "description": "Returns whether the current prototype/instance has a \"notify\"\nproperty effect for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1266,
+              "column": 6
+            },
+            "end": {
+              "line": 1268,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if the prototype/instance has an effect of this type"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_hasReflectEffect",
+          "description": "Returns whether the current prototype/instance has a \"reflect to attribute\"\nproperty effect for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1278,
+              "column": 6
+            },
+            "end": {
+              "line": 1280,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if the prototype/instance has an effect of this type"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_hasComputedEffect",
+          "description": "Returns whether the current prototype/instance has a \"computed\"\nproperty effect for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1290,
+              "column": 6
+            },
+            "end": {
+              "line": 1292,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if the prototype/instance has an effect of this type"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_setPendingPropertyOrPath",
+          "description": "Sets a pending property or path.  If the root property of the path in\nquestion had no accessor, the path is set, otherwise it is enqueued\nvia `_setPendingProperty`.\n\nThis function isolates relatively expensive functionality necessary\nfor the public API (`set`, `setProperties`, `notifyPath`, and property\nchange listeners via {{...}} bindings), such that it is only done\nwhen paths enter the system, and not at every propagation step.  It\nalso sets a `__dataHasPaths` flag on the instance which is used to\nfast-path slower path-matching code in the property effects host paths.\n\n`path` can be a path string or array of path parts as accepted by the\npublic API.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1324,
+              "column": 6
+            },
+            "end": {
+              "line": 1356,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string | !Array.<(number | string)>)",
+              "description": "Path to set"
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "Value to set"
+            },
+            {
+              "name": "shouldNotify",
+              "type": "boolean=",
+              "description": "Set to true if this change should\n cause a property notification event dispatch"
+            },
+            {
+              "name": "isPathNotification",
+              "type": "boolean=",
+              "description": "If the path being set is a path\n  notification of an already changed value, as opposed to a request\n  to set and notify the change.  In the latter `false` case, a dirty\n  check is performed and then the value is set to the path before\n  enqueuing the pending property change."
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "Returns true if the property/path was enqueued in\n  the pending changes bag."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_setUnmanagedPropertyToNode",
+          "description": "Applies a value to a non-Polymer element/node's property.\n\nThe implementation makes a best-effort at binding interop:\nSome native element properties have side-effects when\nre-setting the same value (e.g. setting `<input>.value` resets the\ncursor position), so we do a dirty-check before setting the value.\nHowever, for better interop with non-Polymer custom elements that\naccept objects, we explicitly re-set object changes coming from the\nPolymer world (which may include deep object changes without the\ntop reference changing), erring on the side of providing more\ninformation.\n\nUsers may override this method to provide alternate approaches.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1379,
+              "column": 6
+            },
+            "end": {
+              "line": 1387,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "!Node",
+              "description": "The node to set a property on"
+            },
+            {
+              "name": "prop",
+              "type": "string",
+              "description": "The property to set"
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "The value to set"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_enqueueClient",
+          "description": "Enqueues the given client on a list of pending clients, whose\npending property changes can later be flushed via a call to\n`_flushClients`.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1494,
+              "column": 6
+            },
+            "end": {
+              "line": 1499,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "client",
+              "type": "Object",
+              "description": "PropertyEffects client to enqueue"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_flushClients",
+          "description": "Flushes any clients previously enqueued via `_enqueueClient`, causing\ntheir `_flushProperties` method to run.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1520,
+              "column": 6
+            },
+            "end": {
+              "line": 1531,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__enableOrFlushClients",
+          "description": "(c) the stamped dom enables.",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1545,
+              "column": 6
+            },
+            "end": {
+              "line": 1558,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_readyClients",
+          "description": "Implements `PropertyEffects`'s `_readyClients` call. Attaches\nelement dom by calling `_attachDom` with the dom stamped from the\nelement's template via `_stampTemplate`. Note that this allows\nclient dom to be attached to the element prior to any observers\nrunning.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 621,
+              "column": 6
+            },
+            "end": {
+              "line": 630,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "setProperties",
+          "description": "Sets a bag of property changes to this instance, and\nsynchronously processes all effects of the properties as a batch.\n\nProperty names must be simple properties, not paths.  Batched\npath propagation is not supported.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1587,
+              "column": 6
+            },
+            "end": {
+              "line": 1598,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "Bag of one or more key-value pairs whose key is\n  a property and value is the new value to set for that property."
+            },
+            {
+              "name": "setReadOnly",
+              "type": "boolean=",
+              "description": "When true, any private values set in\n  `props` will be set. By default, `setProperties` will not set\n  `readOnly: true` root properties."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_propagatePropertyChanges",
+          "description": "Called to propagate any property changes to stamped template nodes\nmanaged by this element.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1685,
+              "column": 6
+            },
+            "end": {
+              "line": 1695,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "changedProps",
+              "type": "Object",
+              "description": "Bag of changed properties"
+            },
+            {
+              "name": "oldProps",
+              "type": "Object",
+              "description": "Bag of previous values for changed properties"
+            },
+            {
+              "name": "hasPaths",
+              "type": "boolean",
+              "description": "True with `props` contains one or more paths"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "linkPaths",
+          "description": "Aliases one data path as another, such that path notifications from one\nare routed to the other.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1706,
+              "column": 6
+            },
+            "end": {
+              "line": 1711,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "to",
+              "type": "(string | !Array.<(string | number)>)",
+              "description": "Target path to link."
+            },
+            {
+              "name": "from",
+              "type": "(string | !Array.<(string | number)>)",
+              "description": "Source path to link."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "unlinkPaths",
+          "description": "Removes a data path alias previously established with `_linkPaths`.\n\nNote, the path to unlink should be the target (`to`) used when\nlinking the paths.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1723,
+              "column": 6
+            },
+            "end": {
+              "line": 1728,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string | !Array.<(string | number)>)",
+              "description": "Target path to unlink."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "notifySplices",
+          "description": "Notify that an array has changed.\n\nExample:\n\n    this.items = [ {name: 'Jim'}, {name: 'Todd'}, {name: 'Bill'} ];\n    ...\n    this.items.splice(1, 1, {name: 'Sam'});\n    this.items.push({name: 'Bob'});\n    this.notifySplices('items', [\n      { index: 1, removed: [{name: 'Todd'}], addedCount: 1, object: this.items, type: 'splice' },\n      { index: 3, removed: [], addedCount: 1, object: this.items, type: 'splice'}\n    ]);",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1760,
+              "column": 6
+            },
+            "end": {
+              "line": 1764,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "string",
+              "description": "Path that should be notified."
+            },
+            {
+              "name": "splices",
+              "type": "Array",
+              "description": "Array of splice records indicating ordered\n  changes that occurred to the array. Each record should have the\n  following fields:\n   * index: index at which the change occurred\n   * removed: array of items that were removed from this index\n   * addedCount: number of new items added at this index\n   * object: a reference to the array in question\n   * type: the string literal 'splice'\n\n  Note that splice records _must_ be normalized such that they are\n  reported in index order (raw results from `Object.observe` are not\n  ordered and must be normalized/merged before notifying)."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "get",
+          "description": "Convenience method for reading a value from a path.\n\nNote, if any part in the path is undefined, this method returns\n`undefined` (this method does not throw when dereferencing undefined\npaths).",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1785,
+              "column": 6
+            },
+            "end": {
+              "line": 1787,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string | !Array.<(string | number)>)",
+              "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
+            },
+            {
+              "name": "root",
+              "type": "Object=",
+              "description": "Root object from which the path is evaluated."
+            }
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Value at the path, or `undefined` if any part of the path\n  is undefined."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "set",
+          "description": "Convenience method for setting a value to a path and notifying any\nelements bound to the same path.\n\nNote, if any part in the path except for the last is undefined,\nthis method does nothing (this method does not throw when\ndereferencing undefined paths).",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1810,
+              "column": 6
+            },
+            "end": {
+              "line": 1820,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string | !Array.<(string | number)>)",
+              "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "Value to set at the specified path."
+            },
+            {
+              "name": "root",
+              "type": "Object=",
+              "description": "Root object from which the path is evaluated.\n  When specified, no notification will occur."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "push",
+          "description": "Adds items onto the end of the array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.push`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1836,
+              "column": 6
+            },
+            "end": {
+              "line": 1845,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string | !Array.<(string | number)>)",
+              "description": "Path to array."
+            },
+            {
+              "name": "items",
+              "type": "...*",
+              "rest": true,
+              "description": "Items to push onto array"
+            }
+          ],
+          "return": {
+            "type": "number",
+            "desc": "New length of the array."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "pop",
+          "description": "Removes an item from the end of array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.pop`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1860,
+              "column": 6
+            },
+            "end": {
+              "line": 1869,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string | !Array.<(string | number)>)",
+              "description": "Path to array."
+            }
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Item that was removed."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "splice",
+          "description": "Starting from the start index specified, removes 0 or more items\nfrom the array and inserts 0 or more new items in their place.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.splice`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1888,
+              "column": 6
+            },
+            "end": {
+              "line": 1925,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string | !Array.<(string | number)>)",
+              "description": "Path to array."
+            },
+            {
+              "name": "start",
+              "type": "number",
+              "description": "Index from which to start removing/inserting."
+            },
+            {
+              "name": "deleteCount",
+              "type": "number",
+              "description": "Number of items to remove."
+            },
+            {
+              "name": "items",
+              "type": "...*",
+              "rest": true,
+              "description": "Items to insert into array."
+            }
+          ],
+          "return": {
+            "type": "Array",
+            "desc": "Array of removed items."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "shift",
+          "description": "Removes an item from the beginning of array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.pop`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1940,
+              "column": 6
+            },
+            "end": {
+              "line": 1949,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string | !Array.<(string | number)>)",
+              "description": "Path to array."
+            }
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Item that was removed."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "unshift",
+          "description": "Adds items onto the beginning of the array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.push`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1965,
+              "column": 6
+            },
+            "end": {
+              "line": 1973,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string | !Array.<(string | number)>)",
+              "description": "Path to array."
+            },
+            {
+              "name": "items",
+              "type": "...*",
+              "rest": true,
+              "description": "Items to insert info array"
+            }
+          ],
+          "return": {
+            "type": "number",
+            "desc": "New length of the array."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "notifyPath",
+          "description": "Notify that a path has changed.\n\nExample:\n\n    this.item.user.name = 'Bob';\n    this.notifyPath('item.user.name');",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1988,
+              "column": 6
+            },
+            "end": {
+              "line": 2005,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "string",
+              "description": "Path that should be notified."
+            },
+            {
+              "name": "value",
+              "type": "*=",
+              "description": "Value at the path (optional)."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_createReadOnlyProperty",
+          "description": "Equivalent to static `createReadOnlyProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2018,
+              "column": 6
+            },
+            "end": {
+              "line": 2025,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            },
+            {
+              "name": "protectedSetter",
+              "type": "boolean=",
+              "description": "Creates a custom protected setter\n  when `true`."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_createPropertyObserver",
+          "description": "Equivalent to static `createPropertyObserver` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2039,
+              "column": 6
+            },
+            "end": {
+              "line": 2049,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            },
+            {
+              "name": "method",
+              "type": "(string | function (*, *))",
+              "description": "Function or name of observer method to call"
+            },
+            {
+              "name": "dynamicFn",
+              "type": "boolean=",
+              "description": "Whether the method name should be included as\n  a dependency to the effect."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_createMethodObserver",
+          "description": "Equivalent to static `createMethodObserver` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2062,
+              "column": 6
+            },
+            "end": {
+              "line": 2068,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "expression",
+              "type": "string",
+              "description": "Method expression"
+            },
+            {
+              "name": "dynamicFn",
+              "type": "(boolean | Object)=",
+              "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_createNotifyingProperty",
+          "description": "Equivalent to static `createNotifyingProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2079,
+              "column": 6
+            },
+            "end": {
+              "line": 2087,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_createReflectedProperty",
+          "description": "Equivalent to static `createReflectedProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2098,
+              "column": 6
+            },
+            "end": {
+              "line": 2111,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_createComputedProperty",
+          "description": "Equivalent to static `createComputedProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2125,
+              "column": 6
+            },
+            "end": {
+              "line": 2131,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of computed property to set"
+            },
+            {
+              "name": "expression",
+              "type": "string",
+              "description": "Method expression"
+            },
+            {
+              "name": "dynamicFn",
+              "type": "(boolean | Object)=",
+              "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_marshalArgs",
+          "description": "Gather the argument values for a method specified in the provided array\nof argument metadata.\n\nThe `path` and `value` arguments are used to fill in wildcard descriptor\nwhen the method is being called as a result of a path notification.",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2146,
+              "column": 6
+            },
+            "end": {
+              "line": 2181,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "args",
+              "type": "!Array.<!MethodArg>",
+              "description": "Array of argument metadata"
+            },
+            {
+              "name": "path",
+              "type": "string",
+              "description": "Property/path name that triggered the method effect"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "Bag of current property changes"
+            }
+          ],
+          "return": {
+            "type": "Array.<*>",
+            "desc": "Array of argument values"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_bindTemplate",
+          "description": "Equivalent to static `bindTemplate` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.\n\nThis method may be called on the prototype (for prototypical template\nbinding, to avoid creating accessors every instance) once per prototype,\nand will be called with `runtimeBinding: true` by `_stampTemplate` to\ncreate and link an instance of the template metadata associated with a\nparticular stamping.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2358,
+              "column": 6
+            },
+            "end": {
+              "line": 2381,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "template",
+              "type": "!HTMLTemplateElement",
+              "description": "Template containing binding\n  bindings"
+            },
+            {
+              "name": "instanceBinding",
+              "type": "boolean=",
+              "description": "When false (default), performs\n  \"prototypical\" binding of the template and overwrites any previously\n  bound template for the class. When true (as passed from\n  `_stampTemplate`), the template info is instanced and linked into\n  the list of bound templates."
+            }
+          ],
+          "return": {
+            "type": "!TemplateInfo",
+            "desc": "Template metadata object; for `runtimeBinding`,\n  this is an instance of the prototypical template info"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_removeBoundDom",
+          "description": "Removes and unbinds the nodes previously contained in the provided\nDocumentFragment returned from `_stampTemplate`.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2460,
+              "column": 6
+            },
+            "end": {
+              "line": 2481,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "dom",
+              "type": "!StampedTemplate",
+              "description": "DocumentFragment previously returned\n  from `_stampTemplate` associated with the nodes to be removed"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "connectedCallback",
+          "description": "Provides a default implementation of the standard Custom Elements\n`connectedCallback`.\n\nThe default implementation enables the property effects system and\nflushes any pending properties, and updates shimmed CSS properties\nwhen using the ShadyCSS scoping/custom properties polyfill.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 590,
+              "column": 6
+            },
+            "end": {
+              "line": 595,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "disconnectedCallback",
+          "description": "Called when the element is removed from a document",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/properties-mixin.html",
+            "start": {
+              "line": 226,
+              "column": 6
+            },
+            "end": {
+              "line": 230,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesMixin"
+        },
+        {
+          "name": "_attachDom",
+          "description": "Attaches an element's stamped dom to itself. By default,\nthis method creates a `shadowRoot` and adds the dom to it.\nHowever, this method may be overridden to allow an element\nto put its dom in another location.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 644,
+              "column": 6
+            },
+            "end": {
+              "line": 660,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "dom",
+              "type": "StampedTemplate",
+              "description": "to attach to the element."
+            }
+          ],
+          "return": {
+            "type": "ShadowRoot",
+            "desc": "node to which the dom has been attached."
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "updateStyles",
+          "description": "When using the ShadyCSS scoping and custom property shim, causes all\nshimmed styles in this element (and its subtree) to be updated\nbased on current custom property values.\n\nThe optional parameter overrides inline custom property styles with an\nobject of properties where the keys are CSS properties, and the values\nare strings.\n\nExample: `this.updateStyles({'--color': 'blue'})`\n\nThese properties are retained unless a value of `null` is set.\n\nNote: This function does not support updating CSS mixins.\nYou can not dynamically change the value of an `@apply`.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 683,
+              "column": 6
+            },
+            "end": {
+              "line": 687,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "properties",
+              "type": "Object=",
+              "description": "Bag of custom property key/values to\n  apply to this element."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "resolveUrl",
+          "description": "Rewrites a given URL relative to a base URL. The base URL defaults to\nthe original location of the document containing the `dom-module` for\nthis element. This method will return the same URL before and after\nbundling.\n\nNote that this function performs no resolution for URLs that start\nwith `/` (absolute URLs) or `#` (hash identifiers).  For general purpose\nURL resolution, use `window.URL`.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 704,
+              "column": 6
+            },
+            "end": {
+              "line": 709,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "url",
+              "type": "string",
+              "description": "URL to resolve."
+            },
+            {
+              "name": "base",
+              "type": "string=",
+              "description": "Optional base URL to resolve against, defaults\nto the element's `importPath`"
+            }
+          ],
+          "return": {
+            "type": "string",
+            "desc": "Rewritten URL relative to base"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
         }
       ],
-      "staticMethods": [],
+      "staticMethods": [
+        {
+          "name": "_parseTemplate",
+          "description": "Scans a template to produce template metadata.\n\nTemplate-specific metadata are stored in the object returned, and node-\nspecific metadata are stored in objects in its flattened `nodeInfoList`\narray.  Only nodes in the template that were parsed as nodes of\ninterest contain an object in `nodeInfoList`.  Each `nodeInfo` object\ncontains an `index` (`childNodes` index in parent) and optionally\n`parent`, which points to node info of its parent (including its index).\n\nThe template metadata object returned from this method has the following\nstructure (many fields optional):\n\n```js\n  {\n    // Flattened list of node metadata (for nodes that generated metadata)\n    nodeInfoList: [\n      {\n        // `id` attribute for any nodes with id's for generating `$` map\n        id: {string},\n        // `on-event=\"handler\"` metadata\n        events: [\n          {\n            name: {string},   // event name\n            value: {string},  // handler method name\n          }, ...\n        ],\n        // Notes when the template contained a `<slot>` for shady DOM\n        // optimization purposes\n        hasInsertionPoint: {boolean},\n        // For nested `<template>`` nodes, nested template metadata\n        templateInfo: {object}, // nested template metadata\n        // Metadata to allow efficient retrieval of instanced node\n        // corresponding to this metadata\n        parentInfo: {number},   // reference to parent nodeInfo>\n        parentIndex: {number},  // index in parent's `childNodes` collection\n        infoIndex: {number},    // index of this `nodeInfo` in `templateInfo.nodeInfoList`\n      },\n      ...\n    ],\n    // When true, the template had the `strip-whitespace` attribute\n    // or was nested in a template with that setting\n    stripWhitespace: {boolean},\n    // For nested templates, nested template content is moved into\n    // a document fragment stored here; this is an optimization to\n    // avoid the cost of nested template cloning\n    content: {DocumentFragment}\n  }\n```\n\nThis method kicks off a recursive treewalk as follows:\n\n```\n   _parseTemplate <---------------------+\n     _parseTemplateContent              |\n       _parseTemplateNode  <------------|--+\n         _parseTemplateNestedTemplate --+  |\n         _parseTemplateChildNodes ---------+\n         _parseTemplateNodeAttributes\n           _parseTemplateNodeAttribute\n\n```\n\nThese methods may be overridden to add custom metadata about templates\nto either `templateInfo` or `nodeInfo`.\n\nNote that this method may be destructive to the template, in that\ne.g. event annotations may be removed after being noted in the\ntemplate metadata.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 201,
+              "column": 6
+            },
+            "end": {
+              "line": 212,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "template",
+              "type": "!HTMLTemplateElement",
+              "description": "Template to parse"
+            },
+            {
+              "name": "outerTemplateInfo",
+              "type": "TemplateInfo=",
+              "description": "Template metadata from the outer\n  template, for parsing nested templates"
+            }
+          ],
+          "return": {
+            "type": "!TemplateInfo",
+            "desc": "Parsed template metadata"
+          },
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "_parseTemplateContent",
+          "description": "Overrides `PropertyAccessors` to add map of dynamic functions on\ntemplate info, for consumption by `PropertyEffects` template binding\ncode. This map determines which method templates should have accessors\ncreated for them.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 720,
+              "column": 6
+            },
+            "end": {
+              "line": 723,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "template"
+            },
+            {
+              "name": "templateInfo"
+            },
+            {
+              "name": "nodeInfo"
+            }
+          ],
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_parseTemplateNode",
+          "description": "Overrides default `TemplateStamp` implementation to add support for\nparsing bindings from `TextNode`'s' `textContent`.  A `bindings`\narray is added to `nodeInfo` and populated with binding metadata\nwith information capturing the binding target, and a `parts` array\nwith one or more metadata objects capturing the source(s) of the\nbinding.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2500,
+              "column": 6
+            },
+            "end": {
+              "line": 2514,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Node",
+              "description": "Node to parse"
+            },
+            {
+              "name": "templateInfo",
+              "type": "TemplateInfo",
+              "description": "Template metadata for current template"
+            },
+            {
+              "name": "nodeInfo",
+              "type": "NodeInfo",
+              "description": "Node metadata for current template node"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_parseTemplateChildNodes",
+          "description": "Parses template child nodes for the given root node.\n\nThis method also wraps whitelisted legacy template extensions\n(`is=\"dom-if\"` and `is=\"dom-repeat\"`) with their equivalent element\nwrappers, collapses text nodes, and strips whitespace from the template\nif the `templateInfo.stripWhitespace` setting was provided.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 263,
+              "column": 6
+            },
+            "end": {
+              "line": 303,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "root",
+              "type": "Node",
+              "description": "Root node whose `childNodes` will be parsed"
+            },
+            {
+              "name": "templateInfo",
+              "type": "!TemplateInfo",
+              "description": "Template metadata for current template"
+            },
+            {
+              "name": "nodeInfo",
+              "type": "!NodeInfo",
+              "description": "Node metadata for current template."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "_parseTemplateNestedTemplate",
+          "description": "Overrides default `TemplateStamp` implementation to add support for\nbinding the properties that a nested template depends on to the template\nas `_host_<property>`.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2597,
+              "column": 6
+            },
+            "end": {
+              "line": 2607,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Node",
+              "description": "Node to parse"
+            },
+            {
+              "name": "templateInfo",
+              "type": "TemplateInfo",
+              "description": "Template metadata for current template"
+            },
+            {
+              "name": "nodeInfo",
+              "type": "NodeInfo",
+              "description": "Node metadata for current template node"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_parseTemplateNodeAttributes",
+          "description": "Parses template node attributes and adds node metadata to `nodeInfo`\nfor nodes of interest.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 341,
+              "column": 6
+            },
+            "end": {
+              "line": 350,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Element",
+              "description": "Node to parse"
+            },
+            {
+              "name": "templateInfo",
+              "type": "TemplateInfo",
+              "description": "Template metadata for current template"
+            },
+            {
+              "name": "nodeInfo",
+              "type": "NodeInfo",
+              "description": "Node metadata for current template."
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+          },
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "_parseTemplateNodeAttribute",
+          "description": "Overrides default `TemplateStamp` implementation to add support for\nparsing bindings from attributes.  A `bindings`\narray is added to `nodeInfo` and populated with binding metadata\nwith information capturing the binding target, and a `parts` array\nwith one or more metadata objects capturing the source(s) of the\nbinding.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2535,
+              "column": 6
+            },
+            "end": {
+              "line": 2581,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Element",
+              "description": "Node to parse"
+            },
+            {
+              "name": "templateInfo",
+              "type": "TemplateInfo",
+              "description": "Template metadata for current template"
+            },
+            {
+              "name": "nodeInfo",
+              "type": "NodeInfo",
+              "description": "Node metadata for current template node"
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "description": "Attribute name"
+            },
+            {
+              "name": "value",
+              "type": "string",
+              "description": "Attribute value"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_contentForTemplate",
+          "description": "Returns the `content` document fragment for a given template.\n\nFor nested templates, Polymer performs an optimization to cache nested\ntemplate content to avoid the cost of cloning deeply nested templates.\nThis method retrieves the cached content for a given template.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 396,
+              "column": 6
+            },
+            "end": {
+              "line": 399,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "template",
+              "type": "HTMLTemplateElement",
+              "description": "Template to retrieve `content` for"
+            }
+          ],
+          "return": {
+            "type": "DocumentFragment",
+            "desc": "Content fragment"
+          },
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "createProperties",
+          "description": "Override of PropertiesChanged createProperties to create accessors\nand property effects for all of the properties.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 351,
+              "column": 6
+            },
+            "end": {
+              "line": 355,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "props"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "attributeNameForProperty",
+          "description": "Returns an attribute name that corresponds to the given property.\nThe attribute name is the lowercased property name. Override to\ncustomize this mapping.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 77,
+              "column": 8
+            },
+            "end": {
+              "line": 79,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property to convert"
+            }
+          ],
+          "return": {
+            "type": "string",
+            "desc": "Attribute name corresponding to the given property."
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "typeForProperty",
+          "description": "Overrides `PropertiesChanged` method to return type specified in the\nstatic `properties` object for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/properties-mixin.html",
+            "start": {
+              "line": 190,
+              "column": 6
+            },
+            "end": {
+              "line": 193,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "name",
+              "type": "string",
+              "description": "Name of property"
+            }
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Type to which to deserialize attribute"
+          },
+          "inheritedFrom": "Polymer.PropertiesMixin"
+        },
+        {
+          "name": "createPropertiesForAttributes",
+          "description": "Generates property accessors for all attributes in the standard\nstatic `observedAttributes` array.\n\nAttribute names are mapped to property names using the `dash-case` to\n`camelCase` convention",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 129,
+              "column": 6
+            },
+            "end": {
+              "line": 134,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "addPropertyEffect",
+          "description": "Ensures an accessor exists for the specified property, and adds\nto a list of \"property effects\" that will run when the accessor for\nthe specified property is set.  Effects are grouped by \"type\", which\nroughly corresponds to a phase in effect processing.  The effect\nmetadata should be in the following form:\n\n    {\n      fn: effectFunction, // Reference to function to call to perform effect\n      info: { ... }       // Effect metadata passed to function\n      trigger: {          // Optional triggering metadata; if not provided\n        name: string      // the property is treated as a wildcard\n        structured: boolean\n        wildcard: boolean\n      }\n    }\n\nEffects are called from `_propertiesChanged` in the following order by\ntype:\n\n1. COMPUTE\n2. PROPAGATE\n3. REFLECT\n4. OBSERVE\n5. NOTIFY\n\nEffect functions are called with the following signature:\n\n    effectFunction(inst, path, props, oldProps, info, hasPaths)",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2221,
+              "column": 6
+            },
+            "end": {
+              "line": 2223,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property that should trigger the effect"
+            },
+            {
+              "name": "type",
+              "type": "string",
+              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+            },
+            {
+              "name": "effect",
+              "type": "Object=",
+              "description": "Effect metadata object"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "createPropertyObserver",
+          "description": "Creates a single-property observer for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2235,
+              "column": 6
+            },
+            "end": {
+              "line": 2237,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            },
+            {
+              "name": "method",
+              "type": "(string | function (*, *))",
+              "description": "Function or name of observer method to call"
+            },
+            {
+              "name": "dynamicFn",
+              "type": "boolean=",
+              "description": "Whether the method name should be included as\n  a dependency to the effect."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "createMethodObserver",
+          "description": "Creates a multi-property \"method observer\" based on the provided\nexpression, which should be a string in the form of a normal JavaScript\nfunction signature: `'methodName(arg1, [..., argn])'`.  Each argument\nshould correspond to a property or path in the context of this\nprototype (or instance), or may be a literal string or number.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2252,
+              "column": 6
+            },
+            "end": {
+              "line": 2254,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "expression",
+              "type": "string",
+              "description": "Method expression"
+            },
+            {
+              "name": "dynamicFn",
+              "type": "(boolean | Object)=",
+              "description": "Boolean or object map indicating"
+            }
+          ],
+          "return": {
+            "type": "void",
+            "desc": "whether method names should be included as a dependency to the effect."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "createNotifyingProperty",
+          "description": "Causes the setter for the given property to dispatch `<property>-changed`\nevents to notify of changes to the property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2264,
+              "column": 6
+            },
+            "end": {
+              "line": 2266,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "createReadOnlyProperty",
+          "description": "Creates a read-only accessor for the given property.\n\nTo set the property, use the protected `_setProperty` API.\nTo create a custom protected setter (e.g. `_setMyProp()` for\nproperty `myProp`), pass `true` for `protectedSetter`.\n\nNote, if the property will have other property effects, this method\nshould be called first, before adding other effects.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2284,
+              "column": 6
+            },
+            "end": {
+              "line": 2286,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            },
+            {
+              "name": "protectedSetter",
+              "type": "boolean=",
+              "description": "Creates a custom protected setter\n  when `true`."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "createReflectedProperty",
+          "description": "Causes the setter for the given property to reflect the property value\nto a (dash-cased) attribute of the same name.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2296,
+              "column": 6
+            },
+            "end": {
+              "line": 2298,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "createComputedProperty",
+          "description": "Creates a computed property whose value is set to the result of the\nmethod described by the given `expression` each time one or more\narguments to the method changes.  The expression should be a string\nin the form of a normal JavaScript function signature:\n`'methodName(arg1, [..., argn])'`",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2314,
+              "column": 6
+            },
+            "end": {
+              "line": 2316,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of computed property to set"
+            },
+            {
+              "name": "expression",
+              "type": "string",
+              "description": "Method expression"
+            },
+            {
+              "name": "dynamicFn",
+              "type": "(boolean | Object)=",
+              "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "bindTemplate",
+          "description": "Parses the provided template to ensure binding effects are created\nfor them, and then ensures property accessors are created for any\ndependent properties in the template.  Binding effects for bound\ntemplates are stored in a linked list on the instance so that\ntemplates can be efficiently stamped and unstamped.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2330,
+              "column": 6
+            },
+            "end": {
+              "line": 2332,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "template",
+              "type": "!HTMLTemplateElement",
+              "description": "Template containing binding\n  bindings"
+            }
+          ],
+          "return": {
+            "type": "!TemplateInfo",
+            "desc": "Template metadata object"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_addTemplatePropertyEffect",
+          "description": "Adds a property effect to the given template metadata, which is run\nat the \"propagate\" stage of `_propertiesChanged` when the template\nhas been bound to the element via `_bindTemplate`.\n\nThe `effect` object should match the format in `_addPropertyEffect`.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2396,
+              "column": 6
+            },
+            "end": {
+              "line": 2402,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "templateInfo",
+              "type": "Object",
+              "description": "Template metadata to add effect to"
+            },
+            {
+              "name": "prop",
+              "type": "string",
+              "description": "Property that should trigger the effect"
+            },
+            {
+              "name": "effect",
+              "type": "Object=",
+              "description": "Effect metadata object"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_parseBindings",
+          "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`\n\nThe default implementation uses a regular expression for best\nperformance. However, the regular expression uses a white-list of\nallowed characters in a data-binding, which causes problems for\ndata-bindings that do use characters not in this white-list.\n\nInstead of updating the white-list with all allowed characters,\nthere is a StrictBindingParser (see lib/mixins/strict-binding-parser)\nthat uses a state machine instead. This state machine is able to handle\nall characters. However, it is slightly less performant, therefore we\nextracted it into a separate optional mixin.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2653,
+              "column": 6
+            },
+            "end": {
+              "line": 2718,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "text",
+              "type": "string",
+              "description": "Text to parse from attribute or textContent"
+            },
+            {
+              "name": "templateInfo",
+              "type": "Object",
+              "description": "Current template metadata"
+            }
+          ],
+          "return": {
+            "type": "Array.<!BindingPart>",
+            "desc": "Array of binding part metadata"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_evaluateBinding",
+          "description": "Called to evaluate a previously parsed binding part based on a set of\none or more changed dependencies.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2734,
+              "column": 6
+            },
+            "end": {
+              "line": 2751,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "inst",
+              "type": "this",
+              "description": "Element that should be used as scope for\n  binding dependencies"
+            },
+            {
+              "name": "part",
+              "type": "BindingPart",
+              "description": "Binding part metadata"
+            },
+            {
+              "name": "path",
+              "type": "string",
+              "description": "Property/path that triggered this effect"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "Bag of current property changes"
+            },
+            {
+              "name": "oldProps",
+              "type": "Object",
+              "description": "Bag of previous values for changed properties"
+            },
+            {
+              "name": "hasPaths",
+              "type": "boolean",
+              "description": "True with `props` contains one or more paths"
+            }
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Value the binding part evaluated to"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "finalize",
+          "description": "Finalizes an element definition, including ensuring any super classes\nare also finalized. This includes ensuring property\naccessors exist on the element prototype. This method calls\n`_finalizeClass` to finalize each constructor in the prototype chain.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/properties-mixin.html",
+            "start": {
+              "line": 138,
+              "column": 6
+            },
+            "end": {
+              "line": 147,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesMixin"
+        },
+        {
+          "name": "_finalizeClass",
+          "description": "Override of PropertiesMixin _finalizeClass to create observers and\nfind the template.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 319,
+              "column": 6
+            },
+            "end": {
+              "line": 326,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_prepareTemplate",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 328,
+              "column": 6
+            },
+            "end": {
+              "line": 342,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "createObservers",
+          "description": "Creates observers for the given `observers` array.\nLeverages `PropertyEffects` to create observers.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 368,
+              "column": 6
+            },
+            "end": {
+              "line": 373,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "observers",
+              "type": "Object",
+              "description": "Array of observer descriptors for\n  this class"
+            },
+            {
+              "name": "dynamicFns",
+              "type": "Object",
+              "description": "Object containing keys for any properties\n  that are functions and should trigger the effect when the function\n  reference is changed"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_processStyleText",
+          "description": "Gather style text for a style element in the template.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 553,
+              "column": 6
+            },
+            "end": {
+              "line": 555,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "cssText",
+              "type": "string",
+              "description": "Text containing styling to process"
+            },
+            {
+              "name": "baseURI",
+              "type": "string",
+              "description": "Base URI to rebase CSS paths against"
+            }
+          ],
+          "return": {
+            "type": "string",
+            "desc": "The processed CSS text"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_finalizeTemplate",
+          "description": "Configures an element `proto` to function with a given `template`.\nThe element name `is` and extends `ext` must be specified for ShadyCSS\nstyle scoping.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 566,
+              "column": 6
+            },
+            "end": {
+              "line": 577,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "is",
+              "type": "string",
+              "description": "Tag name (or type extension name) for this element"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        }
+      ],
       "demos": [
         {
           "url": "demo/index.html",
@@ -214,144 +3981,145 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 201,
-          "column": 9
+          "line": 242,
+          "column": 1
         },
         "end": {
-          "line": 254,
+          "line": 296,
           "column": 2
         }
       },
       "privacy": "public",
-      "superclass": "HTMLElement",
+      "superclass": "Polymer.Element",
+      "name": "CosmozI18Next",
       "attributes": [
         {
           "name": "domain",
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 204,
-              "column": 3
+              "line": 248,
+              "column": 4
             },
             "end": {
-              "line": 207,
-              "column": 4
+              "line": 251,
+              "column": 5
             }
           },
           "metadata": {},
-          "type": "string"
+          "type": "string | null | undefined"
         },
         {
           "name": "interpolation-prefix",
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 208,
-              "column": 3
+              "line": 252,
+              "column": 4
             },
             "end": {
-              "line": 211,
-              "column": 4
+              "line": 255,
+              "column": 5
             }
           },
           "metadata": {},
-          "type": "string"
+          "type": "string | null | undefined"
         },
         {
           "name": "interpolation-suffix",
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 212,
-              "column": 3
+              "line": 256,
+              "column": 4
             },
             "end": {
-              "line": 215,
-              "column": 4
+              "line": 259,
+              "column": 5
             }
           },
           "metadata": {},
-          "type": "string"
+          "type": "string | null | undefined"
         },
         {
           "name": "language",
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 216,
-              "column": 3
+              "line": 260,
+              "column": 4
             },
             "end": {
-              "line": 219,
-              "column": 4
+              "line": 263,
+              "column": 5
             }
           },
           "metadata": {},
-          "type": "string"
+          "type": "string | null | undefined"
         },
         {
           "name": "namespace",
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 220,
-              "column": 3
+              "line": 264,
+              "column": 4
             },
             "end": {
-              "line": 223,
-              "column": 4
+              "line": 267,
+              "column": 5
             }
           },
           "metadata": {},
-          "type": "string"
+          "type": "string | null | undefined"
         },
         {
           "name": "translations",
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 224,
-              "column": 3
+              "line": 268,
+              "column": 4
             },
             "end": {
-              "line": 227,
-              "column": 4
+              "line": 275,
+              "column": 5
             }
           },
           "metadata": {},
-          "type": "Object"
+          "type": "Object | null | undefined"
         },
         {
           "name": "key-separator",
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 228,
-              "column": 3
+              "line": 276,
+              "column": 4
             },
             "end": {
-              "line": 231,
-              "column": 4
+              "line": 279,
+              "column": 5
             }
           },
           "metadata": {},
-          "type": "string"
+          "type": "string | null | undefined"
         },
         {
           "name": "ns-separator",
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 232,
-              "column": 3
+              "line": 280,
+              "column": 4
             },
             "end": {
-              "line": 235,
-              "column": 4
+              "line": 283,
+              "column": 5
             }
           },
           "metadata": {},
-          "type": "string"
+          "type": "string | null | undefined"
         }
       ],
       "events": [],
@@ -368,369 +4136,97 @@
       "path": "cosmoz-t.html",
       "properties": [
         {
-          "name": "t",
-          "type": "Object",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-i18next.js",
-            "start": {
-              "line": 10,
-              "column": 3
-            },
-            "end": {
-              "line": 15,
-              "column": 4
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "{}",
-          "inheritedFrom": "Cosmoz.TranslatableBehavior"
-        },
-        {
           "name": "input",
-          "type": "string",
+          "type": "string | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 9,
+              "line": 14,
               "column": 5
             },
             "end": {
-              "line": 11,
+              "line": 16,
               "column": 6
             }
           },
           "metadata": {
-            "polymer": {}
+            "polymer": {
+              "attributeType": "String"
+            }
+          }
+        },
+        {
+          "name": "t",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 17,
+              "column": 5
+            },
+            "end": {
+              "line": 19,
+              "column": 6
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "Object"
+            }
           }
         }
       ],
-      "methods": [
-        {
-          "name": "_argumentsToObject",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-i18next.js",
-            "start": {
-              "line": 18,
-              "column": 2
-            },
-            "end": {
-              "line": 21,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "args"
-            },
-            {
-              "name": "skipnum"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.TranslatableBehavior"
-        },
-        {
-          "name": "_arrayToObject",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-i18next.js",
-            "start": {
-              "line": 23,
-              "column": 2
-            },
-            "end": {
-              "line": 37,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "array"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.TranslatableBehavior"
-        },
-        {
-          "name": "_ensureInitialized",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-i18next.js",
-            "start": {
-              "line": 39,
-              "column": 2
-            },
-            "end": {
-              "line": 45,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "inheritedFrom": "Cosmoz.TranslatableBehavior"
-        },
-        {
-          "name": "_",
-          "description": "Convenience method for `gettext`",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-i18next.js",
-            "start": {
-              "line": 52,
-              "column": 2
-            },
-            "end": {
-              "line": 59,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "key",
-              "type": "String",
-              "description": "Translation key"
-            }
-          ],
-          "return": {
-            "type": "String",
-            "desc": "Translated text"
-          },
-          "inheritedFrom": "Cosmoz.TranslatableBehavior"
-        },
-        {
-          "name": "attached",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-i18next.js",
-            "start": {
-              "line": 61,
-              "column": 2
-            },
-            "end": {
-              "line": 63,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "inheritedFrom": "Cosmoz.TranslatableBehavior"
-        },
-        {
-          "name": "detached",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-i18next.js",
-            "start": {
-              "line": 65,
-              "column": 2
-            },
-            "end": {
-              "line": 70,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "inheritedFrom": "Cosmoz.TranslatableBehavior"
-        },
-        {
-          "name": "gettext",
-          "description": "#### Basic functionality\n##### `_(string, t)`\n    <div>{{ _(‘My translation’, t) }}</div>\n\n#### Interpolation\n##### `_(string, [args], t)`\n    <div>{{ _(‘Hello {0}’, user.name, t) }}</div>",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-i18next.js",
-            "start": {
-              "line": 85,
-              "column": 2
-            },
-            "end": {
-              "line": 92,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "key",
-              "type": "String",
-              "description": "String to translate"
-            }
-          ],
-          "return": {
-            "type": "String",
-            "desc": "Translated string"
-          },
-          "inheritedFrom": "Cosmoz.TranslatableBehavior"
-        },
-        {
-          "name": "ngettext",
-          "description": "#### Plurals\n##### `ngettext(singular, plural, count, t)`\n    <div>{{ ngettext(‘My translation’,\n    \t\t‘My translations’, count, t) }}</div>\n\n#### Plurals with interpolation\n##### `ngettext(singular, plural, [count and other args], t)`\n    <div>{{ ngettext(‘My translation for “{1}”’,\n        \t‘My {0} translations for “{1}”’,\n        \tcount, ‘hello’, t) }}</div>\n_The first number-argument found will be used as ‘count’ to decide plural._",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-i18next.js",
-            "start": {
-              "line": 111,
-              "column": 2
-            },
-            "end": {
-              "line": 129,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "singular",
-              "type": "String",
-              "description": "Singular string"
-            },
-            {
-              "name": "plural",
-              "type": "String",
-              "description": "Plural string"
-            }
-          ],
-          "return": {
-            "type": "String",
-            "desc": "Translated string"
-          },
-          "inheritedFrom": "Cosmoz.TranslatableBehavior"
-        },
-        {
-          "name": "pgettext",
-          "description": "#### Context\n##### `pgettext(context, ‘text’, t)`\n    <div>{{ pgettext(‘Cancel Invoice’,\n    \t\t‘Cancel’, t) }}</div>\n\n#### Context with interpolation\n##### `pgettext(context, ‘text’, [args], t)`\n    <div>{{ pgettext(‘Cancel Invoice’, ‘Cancel {0}’,\n    \t\tdocument.type, t) }}</div>",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-i18next.js",
-            "start": {
-              "line": 146,
-              "column": 2
-            },
-            "end": {
-              "line": 154,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "context",
-              "type": "String",
-              "description": "Context string"
-            },
-            {
-              "name": "key",
-              "type": "String",
-              "description": "String to translate"
-            }
-          ],
-          "return": {
-            "type": "String",
-            "desc": "Translated string"
-          },
-          "inheritedFrom": "Cosmoz.TranslatableBehavior"
-        },
-        {
-          "name": "npgettext",
-          "description": "#### Plurals and context\n##### `npgettext(context, singular, plural, count, t)`\n    <div>{{ npgettext('Cancel invoice',\n    \t\t‘My cancellation’,\n    \t\t‘My {0} cancellations’,\n    \t\tcount, t) }}</div>\n\n#### Plurals and context with interpolation\n##### `npgettext(context, singular, plural, count, t)`\n    <div>{{ npgettext('Cancel invoice',\n    \t\t‘My {1} cancellation’,\n    \t\t‘My {0} {1} cancellations’,\n    \t\tcount, document.type, t) }}</div>",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-i18next.js",
-            "start": {
-              "line": 176,
-              "column": 2
-            },
-            "end": {
-              "line": 198,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "context",
-              "type": "String",
-              "description": "Context string"
-            },
-            {
-              "name": "singular",
-              "type": "String",
-              "description": "Singular string"
-            },
-            {
-              "name": "plural",
-              "type": "String",
-              "description": "Plural string"
-            }
-          ],
-          "return": {
-            "type": "String",
-            "desc": "Translated string"
-          },
-          "inheritedFrom": "Cosmoz.TranslatableBehavior"
-        }
-      ],
+      "methods": [],
       "staticMethods": [],
       "demos": [],
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 6,
-          "column": 11
+          "line": 8,
+          "column": 2
         },
         "end": {
-          "line": 16,
-          "column": 4
+          "line": 22,
+          "column": 3
         }
       },
       "privacy": "public",
       "superclass": "HTMLElement",
+      "name": "CosmozT",
       "attributes": [
-        {
-          "name": "t",
-          "description": "",
-          "sourceRange": {
-            "file": "cosmoz-i18next.js",
-            "start": {
-              "line": 10,
-              "column": 3
-            },
-            "end": {
-              "line": 15,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "type": "Object",
-          "inheritedFrom": "Cosmoz.TranslatableBehavior"
-        },
         {
           "name": "input",
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 9,
+              "line": 14,
               "column": 5
             },
             "end": {
-              "line": 11,
+              "line": 16,
               "column": 6
             }
           },
           "metadata": {},
-          "type": "string"
+          "type": "string | null | undefined"
+        },
+        {
+          "name": "t",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 17,
+              "column": 5
+            },
+            "end": {
+              "line": 19,
+              "column": 6
+            }
+          },
+          "metadata": {},
+          "type": "Object | null | undefined"
         }
       ],
       "events": [],
@@ -742,329 +4238,335 @@
       "tagname": "cosmoz-t"
     }
   ],
-  "metadata": {
-    "polymer": {
-      "behaviors": [
+  "classes": [
+    {
+      "description": "",
+      "summary": "",
+      "path": "cosmoz-i18next.js",
+      "properties": [],
+      "methods": [
         {
-          "description": "",
-          "summary": "",
-          "path": "cosmoz-i18next.js",
-          "properties": [
-            {
-              "name": "t",
-              "type": "Object",
-              "description": "",
-              "privacy": "public",
-              "sourceRange": {
-                "start": {
-                  "line": 10,
-                  "column": 3
-                },
-                "end": {
-                  "line": 15,
-                  "column": 4
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              },
-              "defaultValue": "{}"
-            }
-          ],
-          "methods": [
-            {
-              "name": "_argumentsToObject",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 18,
-                  "column": 2
-                },
-                "end": {
-                  "line": 21,
-                  "column": 3
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "args"
-                },
-                {
-                  "name": "skipnum"
-                }
-              ]
-            },
-            {
-              "name": "_arrayToObject",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 23,
-                  "column": 2
-                },
-                "end": {
-                  "line": 37,
-                  "column": 3
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "array"
-                }
-              ]
-            },
-            {
-              "name": "_ensureInitialized",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 39,
-                  "column": 2
-                },
-                "end": {
-                  "line": 45,
-                  "column": 3
-                }
-              },
-              "metadata": {},
-              "params": []
-            },
-            {
-              "name": "_",
-              "description": "Convenience method for `gettext`",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 52,
-                  "column": 2
-                },
-                "end": {
-                  "line": 59,
-                  "column": 3
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "key",
-                  "type": "String",
-                  "description": "Translation key"
-                }
-              ],
-              "return": {
-                "type": "String",
-                "desc": "Translated text"
-              }
-            },
-            {
-              "name": "attached",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 61,
-                  "column": 2
-                },
-                "end": {
-                  "line": 63,
-                  "column": 3
-                }
-              },
-              "metadata": {},
-              "params": []
-            },
-            {
-              "name": "detached",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 65,
-                  "column": 2
-                },
-                "end": {
-                  "line": 70,
-                  "column": 3
-                }
-              },
-              "metadata": {},
-              "params": []
-            },
-            {
-              "name": "gettext",
-              "description": "#### Basic functionality\n##### `_(string, t)`\n    <div>{{ _(‘My translation’, t) }}</div>\n\n#### Interpolation\n##### `_(string, [args], t)`\n    <div>{{ _(‘Hello {0}’, user.name, t) }}</div>",
-              "privacy": "public",
-              "sourceRange": {
-                "start": {
-                  "line": 85,
-                  "column": 2
-                },
-                "end": {
-                  "line": 92,
-                  "column": 3
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "key",
-                  "type": "String",
-                  "description": "String to translate"
-                }
-              ],
-              "return": {
-                "type": "String",
-                "desc": "Translated string"
-              }
-            },
-            {
-              "name": "ngettext",
-              "description": "#### Plurals\n##### `ngettext(singular, plural, count, t)`\n    <div>{{ ngettext(‘My translation’,\n    \t\t‘My translations’, count, t) }}</div>\n\n#### Plurals with interpolation\n##### `ngettext(singular, plural, [count and other args], t)`\n    <div>{{ ngettext(‘My translation for “{1}”’,\n        \t‘My {0} translations for “{1}”’,\n        \tcount, ‘hello’, t) }}</div>\n_The first number-argument found will be used as ‘count’ to decide plural._",
-              "privacy": "public",
-              "sourceRange": {
-                "start": {
-                  "line": 111,
-                  "column": 2
-                },
-                "end": {
-                  "line": 129,
-                  "column": 3
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "singular",
-                  "type": "String",
-                  "description": "Singular string"
-                },
-                {
-                  "name": "plural",
-                  "type": "String",
-                  "description": "Plural string"
-                }
-              ],
-              "return": {
-                "type": "String",
-                "desc": "Translated string"
-              }
-            },
-            {
-              "name": "pgettext",
-              "description": "#### Context\n##### `pgettext(context, ‘text’, t)`\n    <div>{{ pgettext(‘Cancel Invoice’,\n    \t\t‘Cancel’, t) }}</div>\n\n#### Context with interpolation\n##### `pgettext(context, ‘text’, [args], t)`\n    <div>{{ pgettext(‘Cancel Invoice’, ‘Cancel {0}’,\n    \t\tdocument.type, t) }}</div>",
-              "privacy": "public",
-              "sourceRange": {
-                "start": {
-                  "line": 146,
-                  "column": 2
-                },
-                "end": {
-                  "line": 154,
-                  "column": 3
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "context",
-                  "type": "String",
-                  "description": "Context string"
-                },
-                {
-                  "name": "key",
-                  "type": "String",
-                  "description": "String to translate"
-                }
-              ],
-              "return": {
-                "type": "String",
-                "desc": "Translated string"
-              }
-            },
-            {
-              "name": "npgettext",
-              "description": "#### Plurals and context\n##### `npgettext(context, singular, plural, count, t)`\n    <div>{{ npgettext('Cancel invoice',\n    \t\t‘My cancellation’,\n    \t\t‘My {0} cancellations’,\n    \t\tcount, t) }}</div>\n\n#### Plurals and context with interpolation\n##### `npgettext(context, singular, plural, count, t)`\n    <div>{{ npgettext('Cancel invoice',\n    \t\t‘My {1} cancellation’,\n    \t\t‘My {0} {1} cancellations’,\n    \t\tcount, document.type, t) }}</div>",
-              "privacy": "public",
-              "sourceRange": {
-                "start": {
-                  "line": 176,
-                  "column": 2
-                },
-                "end": {
-                  "line": 198,
-                  "column": 3
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "context",
-                  "type": "String",
-                  "description": "Context string"
-                },
-                {
-                  "name": "singular",
-                  "type": "String",
-                  "description": "Singular string"
-                },
-                {
-                  "name": "plural",
-                  "type": "String",
-                  "description": "Plural string"
-                }
-              ],
-              "return": {
-                "type": "String",
-                "desc": "Translated string"
-              }
-            }
-          ],
-          "staticMethods": [],
-          "demos": [],
-          "metadata": {},
+          "name": "_argumentsToObject",
+          "description": "Convert arguments to an object, skipping some argument.",
+          "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 8,
-              "column": 1
+              "line": 38,
+              "column": 2
             },
             "end": {
-              "line": 199,
+              "line": 41,
               "column": 3
             }
           },
-          "privacy": "public",
-          "name": "Cosmoz.TranslatableBehavior",
-          "attributes": [
+          "metadata": {},
+          "params": [
             {
-              "name": "t",
-              "description": "",
-              "sourceRange": {
-                "start": {
-                  "line": 10,
-                  "column": 3
-                },
-                "end": {
-                  "line": 15,
-                  "column": 4
-                }
-              },
-              "metadata": {},
-              "type": "Object"
+              "name": "args",
+              "type": "array",
+              "description": "Arguments."
+            },
+            {
+              "name": "skipnum",
+              "type": "number",
+              "description": "Argument number to skip."
             }
           ],
-          "events": [],
-          "styling": {
-            "cssVariables": [],
-            "selectors": []
+          "return": {
+            "type": "object",
+            "desc": "Resulting object with arguments."
+          }
+        },
+        {
+          "name": "_arrayToObject",
+          "description": "Convert an array to an object.",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 48,
+              "column": 2
+            },
+            "end": {
+              "line": 62,
+              "column": 3
+            }
           },
-          "slots": []
+          "metadata": {},
+          "params": [
+            {
+              "name": "array",
+              "type": "array",
+              "description": "Array to convert."
+            }
+          ],
+          "return": {
+            "type": "object",
+            "desc": "Resulting object."
+          }
+        },
+        {
+          "name": "_ensureInitialized",
+          "description": "Ensure mixin is initialized.",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 68,
+              "column": 2
+            },
+            "end": {
+              "line": 74,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          }
+        },
+        {
+          "name": "_",
+          "description": "Convenience method for gettext. Translates a text.",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 81,
+              "column": 2
+            },
+            "end": {
+              "line": 83,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "key",
+              "type": "string",
+              "description": "Translation key."
+            }
+          ],
+          "return": {
+            "type": "string",
+            "desc": "Translated text."
+          }
+        },
+        {
+          "name": "connectedCallback",
+          "description": "Runs when connected.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 88,
+              "column": 2
+            },
+            "end": {
+              "line": 91,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          }
+        },
+        {
+          "name": "disconnectedCallback",
+          "description": "Runs when disconnected.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 96,
+              "column": 2
+            },
+            "end": {
+              "line": 102,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          }
+        },
+        {
+          "name": "gettext",
+          "description": "Translates a text.\n\nExample of basic translation:\n`_(string, t)`\n  <div>{{ _(‘My translation’, t) }}</div>\n\nExample of basic translation with interpolation:\n`_(string, [args], t)`\n  <div>{{ _(‘Hello {0}’, user.name, t) }}</div>",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 118,
+              "column": 2
+            },
+            "end": {
+              "line": 120,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "key",
+              "type": "string",
+              "description": "Text to translate."
+            }
+          ],
+          "return": {
+            "type": "string",
+            "desc": "Translated text."
+          }
+        },
+        {
+          "name": "gettextgeneric",
+          "description": "Generic handler for text translation",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 128,
+              "column": 2
+            },
+            "end": {
+              "line": 134,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "key",
+              "type": "string",
+              "description": "Text to translate."
+            },
+            {
+              "name": "callerArgs",
+              "type": "array",
+              "description": "Arguments from the calling function."
+            }
+          ],
+          "return": {
+            "type": "string",
+            "desc": "Translated text."
+          }
+        },
+        {
+          "name": "ngettext",
+          "description": "Plural version of gettext. Translates a text to the current locale\nusing the first numeric argument after the two first arguments to\ndetermine if output should be singular or plural.\n\nExample of translation in singular or plural:\n`ngettext(singular, plural, count, t)`\n<div>{{ ngettext(‘My translation’,\n  ‘My translations’, count, t) }}</div>\n\nExample of translation in singular or plural with interpolation:\n`ngettext(singular, plural, [count and other args], t)`\n<div>{{ ngettext(‘My translation for “{1}”’,\n  ‘My {0} translations for “{1}”’, count, ‘hello’, t) }}</div>",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 154,
+              "column": 2
+            },
+            "end": {
+              "line": 172,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "singular",
+              "type": "string",
+              "description": "Singular text variant."
+            },
+            {
+              "name": "plural",
+              "type": "string",
+              "description": "Plural text variant."
+            }
+          ],
+          "return": {
+            "type": "string",
+            "desc": "Translated text."
+          }
+        },
+        {
+          "name": "pgettext",
+          "description": "Translates a text using a specific context.\n\nExample of translation with context:\n`pgettext(context, ‘text’, t)`\n  <div>{{ pgettext(‘Cancel Invoice’, ‘Cancel’, t) }}</div>\n\nExample of translation including context with interpolation:\n`pgettext(context, ‘text’, [args], t)`\n<div>{{ pgettext(‘Cancel Invoice’, ‘Cancel {0}’,\n  document.type, t) }}</div>",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 189,
+              "column": 2
+            },
+            "end": {
+              "line": 197,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "context",
+              "type": "string",
+              "description": "Context text."
+            },
+            {
+              "name": "key",
+              "type": "string",
+              "description": "Text to translate."
+            }
+          ],
+          "return": {
+            "type": "string",
+            "desc": "Translated text."
+          }
+        },
+        {
+          "name": "npgettext",
+          "description": "Translates a text in singular or plural with a specific context.\n\nExample of translation in singular or plural with context:\n`npgettext(context, singular, plural, count, t)`\n<div>{{ npgettext('Cancel invoice', ‘My cancellation’,\n  ‘My {0} cancellations’, count, t) }}</div>\n\nExample of translation in singular or plural with context and\ninterpolation:\n`npgettext(context, singular, plural, count, t)`\n<div>{{ npgettext('Cancel invoice', ‘My {1} cancellation’,\n  ‘My {0} {1} cancellations’, count, document.type, t) }}</div>",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 217,
+              "column": 2
+            },
+            "end": {
+              "line": 239,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "context",
+              "type": "string",
+              "description": "Context text."
+            },
+            {
+              "name": "singular",
+              "type": "string",
+              "description": "Singular text variant."
+            },
+            {
+              "name": "plural",
+              "type": "string",
+              "description": "Plural text variant."
+            }
+          ],
+          "return": {
+            "type": "string",
+            "desc": "Translated text."
+          }
         }
-      ]
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 16,
+          "column": 43
+        },
+        "end": {
+          "line": 240,
+          "column": 2
+        }
+      },
+      "privacy": "public",
+      "superclass": "baseClass"
     }
-  }
+  ]
 }

--- a/cosmoz-i18next.js
+++ b/cosmoz-i18next.js
@@ -5,25 +5,47 @@
 	window.Cosmoz = window.Cosmoz || {};
 
 	const translationElements = [];
-	/**
-	 * Translation behavior using the I18next internationalization framework.
-	 *
-	 * @polymerBehavior */
-	Cosmoz.TranslatableBehavior = {
-		properties: {
-			t: {
-				type: Object,
-				value() {
-					return {};
-				}
-			}
-		},
 
+	/**
+	* @namespace Cosmoz.Mixins
+	*/
+	Cosmoz.Mixins = Cosmoz.Mixins || {};
+	/**
+	* @memberof Cosmoz.Mixins
+	*/
+
+	Cosmoz.Mixins.translatable = baseClass => class extends baseClass {
+		/**
+		 * Get mixin properties.
+		 * @returns {object} Mixin properties.
+		*/
+		static get properties() {
+			return {
+				t: {
+					type: Object,
+					value() {
+						return {};
+					}
+				}
+			};
+		}
+		/**
+		 * Convert arguments to an object, skipping some argument.
+		 *
+		 * @param {array} args Arguments.
+		 * @param {number} skipnum Argument number to skip.
+		 * @returns {object} Resulting object with arguments.
+		 */
 		_argumentsToObject(args, skipnum) {
 			const argsArray = Array.prototype.slice.call(args, skipnum);
 			return this._arrayToObject(argsArray);
-		},
-
+		}
+		/**
+		 * Convert an array to an object.
+		 *
+		 * @param {array} array Array to convert.
+		 * @returns {object} Resulting object.
+		 */
 		_arrayToObject(array) {
 			const ctx = this,
 				object = {};
@@ -38,16 +60,19 @@
 				}
 			});
 			return object;
-		},
-
+		}
+		/**
+		 * Ensure mixin is initialized.
+		 *
+		 * @returns {void}
+		 */
 		_ensureInitialized() {
 			if (!i18n.isInitialized()) {
 				// default i18n init, to ensure translate function will return something
 				// even when there is no <i18next> element in the page.
 				i18n.init({lng: 'en', resStore: { en: {}}, fallbackLng: false});
 			}
-		},
-
+		}
 		/**
 		 * Convenience method for gettext. Translates a text.
 		 *
@@ -56,19 +81,26 @@
 		 */
 		_(key) {
 			return this.gettextgeneric(key, arguments);
-		},
-
-		attached() {
+		}
+		/**
+		 * Runs when connected.
+		 * @returns {void}
+		 */
+		connectedCallback() {
+			super.connectedCallback();
 			translationElements.push(this);
-		},
-
-		detached() {
+		}
+		/**
+		 * Runs when disconnected.
+		 * @returns {void}
+		 */
+		disconnectedCallback() {
+			super.connectedCallback();
 			const i = translationElements.indexOf(this);
 			if (i >= 0) {
 				translationElements.splice(i, 1);
 			}
-		},
-
+		}
 		/**
 		 * Translates a text.
 		 *
@@ -86,7 +118,7 @@
 		 */
 		gettext(key) {
 			return this.gettextgeneric(key, arguments);
-		},
+		}
 		/**
 		 * Generic handler for text translation
 		 *
@@ -100,8 +132,7 @@
 			// Don't make i18next fetch more translations
 			delete args.count;
 			return i18n.t(key, args);
-		},
-
+		}
 		/**
 		 * Plural version of gettext. Translates a text to the current locale
 		 * using the first numeric argument after the two first arguments to
@@ -139,8 +170,7 @@
 				args.defaultValue = singular;
 			}
 			return i18n.t(key, args);
-		},
-
+		}
 		/**
 		 * Translates a text using a specific context.
 		 *
@@ -165,8 +195,7 @@
 			// Don't make i18next fetch more translations
 			delete args.count;
 			return i18n.t(key, args);
-		},
-
+		}
 		/**
 		 * Translates a text in singular or plural with a specific context.
 		 *
@@ -210,9 +239,6 @@
 			return i18n.t(key, args);
 		}
 	};
-
-	Cosmoz.Mixins = Cosmoz.Mixins || {};
-	Cosmoz.Mixins.translatable = baseClass => Polymer.mixinBehaviors([Cosmoz.TranslatableBehavior], baseClass);
 
 	class CosmozI18Next extends Polymer.Element {
 		static get is() {

--- a/cosmoz-t.html
+++ b/cosmoz-t.html
@@ -20,10 +20,6 @@
 					}
 				};
 			}
-			_() {
-				// FIXME: remove this when TranslatableBehavior is a 2.x mixin
-				return Cosmoz.TranslatableBehavior._.apply(this, arguments);
-			}
 		}
 		customElements.define(CosmozT.is, CosmozT);
 	</script>

--- a/test/basic.html
+++ b/test/basic.html
@@ -28,21 +28,15 @@
 		</test-fixture>
 
 		<script>
-
 			suite('basic', function () {
-				var element;
+				let element;
 
-				setup(function (done){
+				setup(done => {
 					element = fixture('basic');
 					done();
 				});
 
-				test('instantiates a cosmoz-i18next element', function (done){
-					assert.equal(element.is, 'cosmoz-i18next');
-					done();
-				});
-
-				test('sets defaults', function (done){
+				test('sets defaults', done => {
 					assert.equal(element.domain, 'messages');
 					assert.equal(element.interpolationPrefix, '__');
 					assert.equal(element.interpolationSuffix, '__');
@@ -50,34 +44,26 @@
 					assert.equal(element.namespace, 'translation');
 					assert.equal(element.keySeparator, '.');
 					assert.equal(element.nsSeparator, ':');
-
 					done();
 				});
-
 			});
 
-			suite('basic-t', function () {
-				var element;
+			suite('basic-t', () => {
+				let element;
 
-				setup(function (done){
+				setup(done => {
 					element = fixture('basic-t');
 					done();
 				});
 
-				test('instantiates a cosmoz-t element', function (done){
-					assert.equal(element.is, 'cosmoz-t');
-					done();
-				});
-
-				test('translates key', function (done){
+				test('translates key', done => {
 					assert.isFunction(element._);
-					flush(function (){
+					flush(() => {
 						assert.isTrue(i18n.isInitialized());
 						assert.equal(element._('Hello __0__', 'John Doe'), 'Hello John Doe');
 						done();
 					}, 90);
 				});
-
 			});
 		</script>
 	</body>


### PR DESCRIPTION
Components, Test, converting to class-style.

This removes the `Cosmoz.TranslatableBehavior` and it should be put in a new version, so components using workarounds that relies on this behavior can be safely upgraded.

Testing, do `yarn install; yarn start`, add `demo/` to the address. Also do `yarn test`.

Issue is https://github.com/Neovici/cosmoz-frontend/issues/815.