### PR TITLE
fix: disable escape values

### DIFF
--- a/cosmoz-i18next.js
+++ b/cosmoz-i18next.js
@@ -293,6 +293,7 @@ class CosmozI18Next extends PolymerElement {
 		super.ready();
 		i18n.init({
 			interpolation: {
+				escapeValue: false,
 				prefix: this.interpolationPrefix,
 				suffix: this.interpolationSuffix
 			},


### PR DESCRIPTION
Testing, check that the parameter in `_('Example {0}', parameter)` is not converted to an HTML entity when it contains a slash or other escapable character.
