### PR TITLE
fix: correct keyseparator and nsseparator property namings

### DIFF
--- a/cosmoz-i18next.js
+++ b/cosmoz-i18next.js
@@ -10,7 +10,9 @@ const
 			// even when there is no <i18next> element in the page.
 			i18n.init({
 				lng: 'en',
-				resStore: { en: {} },
+				resStore: {
+					en: {}
+				},
 				fallbackLng: false
 			});
 		}
@@ -94,7 +96,9 @@ const
 		return i18n.t(key, args);
 	},
 	loadTranslations = (lang, namespace, translations) => {
-		i18n.init({ resources: {} });
+		i18n.init({
+			resources: {}
+		});
 		i18n.addResourceBundle(lang, namespace, translations);
 	},
 	translatable = dedupingMixin(baseClass => class extends baseClass {

--- a/cosmoz-i18next.js
+++ b/cosmoz-i18next.js
@@ -297,9 +297,9 @@ class CosmozI18Next extends PolymerElement {
 				prefix: this.interpolationPrefix,
 				suffix: this.interpolationSuffix
 			},
-			keyseparator: this.keySeparator,
+			keySeparator: this.keySeparator,
 			lng: this.language,
-			nsseparator: this.nsSeparator,
+			nsSeparator: this.nsSeparator,
 			resStore: {}
 		});
 	}


### PR DESCRIPTION
Check that key-separator and ns-separator properties work as intended.

Related: https://github.com/i18next/react-i18next/issues/387.

Thanks to @cristinecula and @fredrikbernholm for the suggestions on how to solve this.

RM:23551.
