### PR TITLE
ci: standardize CI workflow and add id-token permission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,13 @@ on:
     branches:
       - beta
       - master
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   build:
     uses: Neovici/cfg/.github/workflows/forge.yml@master


### PR DESCRIPTION
## Summary
- Rename workflow.yml to ci.yml
- Add `id-token: write` permission for npm trusted publishing

Relates to NEO-737