### PR TITLE
feat!: upgrade i18next to ^26.0.0 and v4 JSON format

### DIFF
--- a/cosmoz-i18next.js
+++ b/cosmoz-i18next.js
@@ -61,11 +61,11 @@ const
 		delete args.count;
 
 		const pluralSuffix = i18n.services.pluralResolver.getSuffix(i18n.language, n);
-		if (pluralSuffix) {
+		if (pluralSuffix && pluralSuffix !== '_one') {
 			args.defaultValue = plural;
 			key = singular + pluralSuffix;
 		} else {
-			key = singular;
+			key = singular + (pluralSuffix || '');
 			args.defaultValue = singular;
 		}
 		return i18n.t(key, args);
@@ -90,11 +90,12 @@ const
 		delete args.count;
 
 		const pluralSuffix = i18n.services.pluralResolver.getSuffix(i18n.language, n);
-		if (pluralSuffix) {
+		if (pluralSuffix && pluralSuffix !== '_one') {
 			args.defaultValue = plural;
 			key = singular + contextKeyPart + pluralSuffix;
 		} else {
-			key = singular;
+			key = singular + contextKeyPart + (pluralSuffix || '');
+			args.defaultValue = singular;
 			args.context = context;
 		}
 
@@ -258,10 +259,6 @@ const
 class CosmozI18Next extends PolymerElement {
 	static get properties() {  
 		return {
-			compatibilityJSON: {
-				type: String,
-				value: 'v3',
-			},
 			domain: {
 				type: String,
 				value: 'messages'
@@ -305,7 +302,6 @@ class CosmozI18Next extends PolymerElement {
 	ready() {
 		super.ready();
 		i18n.init({
-			compatibilityJSON: this.compatibilityJSON,
 			interpolation: {
 				escapeValue: false,
 				prefix: this.interpolationPrefix,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.3.1",
-        "i18next": "^23.0.0"
+        "i18next": ">=25.0.0 <27.0.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.8.1",
@@ -104,15 +104,6 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -9046,26 +9037,31 @@
       }
     },
     "node_modules/i18next": {
-      "version": "23.16.8",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz",
-      "integrity": "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==",
+      "version": "26.0.10",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.10.tgz",
+      "integrity": "sha512-k3yGPAlWR2RdMYoVXJoDZDT87qeHIWKH7gVksdZMpRty7QX/D9QZeYGvN08KGbKHke9wn01eYT+EEsrqX/YTlw==",
       "funding": [
         {
           "type": "individual",
-          "url": "https://locize.com"
-        },
-        {
-          "type": "individual",
-          "url": "https://locize.com/i18next.html"
+          "url": "https://www.locize.com/i18next"
         },
         {
           "type": "individual",
           "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.2"
+      "peerDependencies": {
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/iconv-lite": {
@@ -16451,7 +16447,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@polymer/polymer": "^3.3.1",
-    "i18next": "^23.0.0"
+    "i18next": ">=25.0.0 <27.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",

--- a/test/translations.json
+++ b/test/translations.json
@@ -1,12 +1,11 @@
 {
     "Hello {0}": "Hej {0}",
-    "Hello {0}_plural": "Hej alla {0}",
-    "{0} invoice": "{0} faktura",
-    "{0} invoice_plural": "{0} fakturor",
+    "{0} invoice_one": "{0} faktura",
+    "{0} invoice_other": "{0} fakturor",
     "Cancel": "Avbryt",
     "Cancel_invoice": "Makulera",
-    "Cancel {0} invoice": "Makulera en faktura",
-    "Cancel {0} invoice_plural": "Makulera {0} fakturor",
-    "Cancel {0} invoice_supplier": "Makulera en leverantörsfaktura",
-	"Cancel {0} invoice_supplier_plural": "Makulera {0} leverantörsfakturor"
+    "Cancel {0} invoice_one": "Makulera en faktura",
+    "Cancel {0} invoice_other": "Makulera {0} fakturor",
+    "Cancel {0} invoice_supplier_one": "Makulera en leverantörsfaktura",
+    "Cancel {0} invoice_supplier_other": "Makulera {0} leverantörsfakturor"
 }


### PR DESCRIPTION
## Summary

- Remove `compatibilityJSON` property and config (removed in i18next v24+)
- Upgrade i18next range to `>=25.0.0 <27.0.0`
- Convert test translations from v3 (`_plural`) to v4 (`_one`/`_other`) format
- Update `ngettext`/`npgettext` to handle `_one` singular suffix

## Breaking Changes

- Minimum i18next version: **25.0.0**
- Translation format: v3 → v4 (`_plural` → `_other`, singular → `_one`)
- `compatibilityJSON` component property removed

## Migration

- Update translation files: `_plural` → `_other`
- Add `_one` suffix for singular plural forms
- Use `compatibilityJSON: 'v4'` in i18next-scanner config

## Tests

- ✅ 9/9 tests pass (Chromium + Firefox)
- ✅ i18next v26.0.10

## Related

Addresses [FE-610](https://linear.app/neovici/issue/FE-610) · Fixes duplicate i18next singleton in [FE-609](https://linear.app/neovici/issue/FE-609)